### PR TITLE
fix: Add missing coach-athlete-index to DynamoDB

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -122,6 +122,15 @@ Resources:
               KeyType: HASH
           Projection:
             ProjectionType: ALL
+        - IndexName: coach-athlete-index
+          KeySchema:
+            - AttributeName: coach_id
+              KeyType: HASH
+            - AttributeName: athlete_id
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+
   
   BlocksTable:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
### Add coach-athlete-index to RelationshipsTable GSI

This PR fixes a ValidationException error in the relationship creation functionality by adding the missing coach-athlete-index to the RelationshipsTable Global Secondary Index in template.yaml. This index enables efficient queries for relationships by coach-athlete pairs.