### PR TITLE
feat: Add endpoint to get relationship by ID

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -51,6 +51,7 @@ ROUTE_CONFIG = {
     "POST /relationships/{relationship_id}/accept": relationship.accept_relationship,
     "POST /relationships/{relationship_id}/end": relationship.end_relationship,
     "GET /coaches/{coach_id}/relationships": relationship.get_relationships_for_coach,
+    "GET /relationships/{relationship_id}": relationship.get_relationship,
     
     # Analytics routes
     # "GET /analytics/athletes/{athlete_id}/max-weight": analytics.get_max_weight_history,

--- a/src/api/relationship.py
+++ b/src/api/relationship.py
@@ -92,3 +92,23 @@ def get_relationships_for_coach(event, context):
     except Exception as e:
         logger.error(f"Error getting relationships: {str(e)}")
         return create_response(500, {"error": str(e)})
+
+def get_relationship(event, context):
+    """
+    Handle GET /relationships/{relationship_id} request to retrieve a relationship by ID
+    """
+    try:
+        # Extract relationship_id from path parameters
+        relationship_id = event["pathParameters"]["relationship_id"]
+
+        # Get relationship
+        relationship = relationship_service.get_relationship(relationship_id)
+
+        if not relationship:
+            return create_response(404, {"error": "Relationship not found"})
+        
+        return create_response(200, relationship.to_dict())
+    
+    except Exception as e:
+        logger.error(f"Error getting relationship: {str(e)}")
+        return create_response(500, {"error": str(e)})


### PR DESCRIPTION
### Get Relationship by ID Endpoint

This PR adds a new API endpoint to retrieve a relationship by its ID.

- Added get_relationship function in src/api/relationship.py to handle GET requests for a single relationship
- Updated the router configuration in handler.py to include the new endpoint