### PR TITLE
fix: Removed 's' from relationships to retrieve by ID

### DIFF
--- a/src/repositories/relationship_repository.py
+++ b/src/repositories/relationship_repository.py
@@ -7,7 +7,7 @@ class RelationshipRepository(BaseRepository):
     def __init__(self):
         super().__init__(os.environ.get("RELATIONSHIPS_TABLE", "Relationships"))
 
-    def get_relationships(self, relationship_id: str) -> Optional[Dict[str, Any]]:
+    def get_relationship(self, relationship_id: str) -> Optional[Dict[str, Any]]:
         """
         Retrieves a relationship by its ID.
 


### PR DESCRIPTION
### Fix Relationship Repository Method Name
This PR fixes an issue with the relationship management functionality where the repository and service layers had inconsistent method naming.

Renamed the method in RelationshipRepository from get_relationships to get_relationship to match the service layer's expectations