### PR TITLE
fix: Align relationship repository method name

### DIFF
--- a/src/repositories/relationship_repository.py
+++ b/src/repositories/relationship_repository.py
@@ -16,7 +16,7 @@ class RelationshipRepository(BaseRepository):
         """
         return self.get_by_id("relationship_id", relationship_id)
     
-    def get_relationships_by_coach(self, coach_id: str, status: Optional[str] = None) -> List[Dict[str, Any]]:
+    def get_relationships_for_coach(self, coach_id: str, status: Optional[str] = None) -> List[Dict[str, Any]]:
         """
         Retrieves relationships by coach ID, optionally filtered by status.
         


### PR DESCRIPTION
Resolves an API error with the coach relationships endpoint by aligning method naming between repository and service layers. This PR fixes the inconsistency where the relationship service expects ```get_relationships_for_coach()``` but the repository implemented ```get_relationships_by_coach()```.