### PR TITLE
fix: Handle DynamoDB Decimal values in JSON responses

### DIFF
--- a/src/utils/response.py
+++ b/src/utils/response.py
@@ -1,5 +1,12 @@
 import json
 from typing import Dict, Any, Union
+from decimal import Decimal
+
+class DecimalEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Decimal):
+            return float(obj)
+        return super(DecimalEncoder, self).default(obj)
 
 def create_response(status_code: int, body: Union[Dict[str, Any], list]) -> Dict[str, Any]:
     """
@@ -17,5 +24,5 @@ def create_response(status_code: int, body: Union[Dict[str, Any], list]) -> Dict
             "Access-Control_Allow-Methods": "OPTIONS,GET,POST,PUT,DELTE",
             "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Amz-Date,X-Api-Key"
         },
-        "body": json.dumps(body)
+        "body": json.dumps(body, cls=DecimalEncoder)
     }

--- a/tests/utils/test_response.py
+++ b/tests/utils/test_response.py
@@ -1,12 +1,18 @@
 import unittest
 import json
-from src.utils.response import create_response
+from src.utils.response import create_response, DecimalEncoder
+from decimal import Decimal
 
 class TestResponseUtil(unittest.TestCase):
-    """Test suite for the response utility"""
+    """
+    Test suite for the response utility
+    """
 
     def test_create_response_with_dict(self):
-        """Test creating a response with a dictionary body"""
+        """
+        Test creating a response with a dictionary body
+        """
+
         # Setup
         status_code = 200
         body = {"message": "Success", "data": {"id": 123}}
@@ -25,7 +31,10 @@ class TestResponseUtil(unittest.TestCase):
         self.assertEqual(parsed_body["data"]["id"], 123)
     
     def test_create_response_with_list(self):
-        """Test creating a response with a list body"""
+        """
+        Test creating a response with a list body
+        """
+        
         # Setup
         status_code = 200
         body = [{"id": 1, "name": "Item 1"}, {"id": 2, "name": "Item 2"}]
@@ -43,7 +52,10 @@ class TestResponseUtil(unittest.TestCase):
         self.assertEqual(parsed_body[1]["name"], "Item 2")
     
     def test_create_response_error(self):
-        """Test creating an error response"""
+        """
+        Test creating an error response
+        """
+
         # Setup
         status_code = 400
         body = {"error": "Bad Request", "details": "Missing required fields"}
@@ -60,7 +72,10 @@ class TestResponseUtil(unittest.TestCase):
         self.assertEqual(parsed_body["details"], "Missing required fields")
     
     def test_create_response_empty(self):
-        """Test creating a response with an empty body"""
+        """
+        Test creating a response with an empty body
+        """
+
         # Setup
         status_code = 204
         body = {}
@@ -74,6 +89,87 @@ class TestResponseUtil(unittest.TestCase):
         # Parse the body JSON and check content
         parsed_body = json.loads(response["body"])
         self.assertEqual(parsed_body, {})
+    
+    def test_create_response_with_decimal(self):
+        """
+        Test creating a response with Decimal values
+        """
+
+        # Setup 
+        status_code = 200
+        body = [
+            {
+                "week_id": "week123",
+                "block_id": "block456",
+                "week_number": Decimal("1"),
+                "notes": "Deload"
+            },
+            {
+                "week_id": "week124",
+                "block_id": "block456",
+                "week_number": Decimal("2"),
+                "notes": "Slight ramp up"
+            },
+            {
+                "week_id": "week125",
+                "block_id": "block456",
+                "week_number": Decimal("3"),
+                "notes": "Push"
+            },
+            {
+                "week_id": "week126",
+                "block_id": "block456",
+                "week_number": Decimal("4"),
+                "notes": "Push"
+            }
+        ]
+        
+        # Call utility
+        response = create_response(status_code, body)
+
+        # Assert
+        self.assertEqual(response["statusCode"], 200)
+
+        # Parse the body JSON and check content
+        parsed_body = json.loads(response["body"])
+        self.assertEqual(len(parsed_body), 4)
+        self.assertEqual(parsed_body[0]["week_number"], 1)
+        self.assertEqual(parsed_body[1]["week_number"], 2)
+        self.assertEqual(parsed_body[2]["week_number"], 3)
+        self.assertEqual(parsed_body[3]["week_number"], 4)
+
+        # Ensure decimal values were properly converted to floats
+        self.assertIsInstance(parsed_body[0]["week_number"], float)
+        self.assertIsInstance(parsed_body[1]["week_number"], float)
+        self.assertIsInstance(parsed_body[2]["week_number"], float)
+        self.assertIsInstance(parsed_body[3]["week_number"], float)
+    
+    def test_decimal_encoder(self):
+        """
+        Test the DecimalEncoder with project test data
+        """
+        
+        # Setup 
+        encoder = DecimalEncoder()
+        
+        # Test with a typical week number
+        week_number = Decimal("3")
+
+        # Test weight value
+        weight = Decimal("308.65")
+
+        # Test RPE value
+        rpe = Decimal("7.5")
+
+        # Assert proper conversion to floats
+        self.assertEqual(encoder.default(week_number), 3.0)
+        self.assertEqual(encoder.default(weight), 308.65)
+        self.assertEqual(encoder.default(rpe), 7.5)
+
+        # Assert types
+        self.assertIsInstance(encoder.default(week_number), float)
+        self.assertIsInstance(encoder.default(weight), float)
+        self.assertIsInstance(encoder.default(rpe), float)
 
 if __name__ == "__main__": # pragma: no cover
     unittest.main()


### PR DESCRIPTION
This PR fixes the "Object of type Decimal is not JSON serializable" error when retrieving weeks from DynamoDB. 
- Added a custom DecimalEncoder to convert Decimal objects to floats
- Updated create_response() to use the custom encoder
- Added tests to verify proper handling of Decimal values

This fix ensures consistent handling of numeric values across all API responses.