### PR TITLE
chore: Remove Pynamodb from dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ pydantic==1.9.0
 mypy-boto3-dynamodb==1.24.0
 aws-lambda-powertools==1.25.6
 aws-xray-sdk==2.10.0
-pynamodb==6.0.2


### PR DESCRIPTION
Decided to not implement Pynamodb at this stage. Want to focus on getting basic operations setup without changing the models.