### PR TITLE
Fix/coach athletes display dashboard

### DIFF
--- a/flow-frontend/src/components/ExerciseTracker.tsx
+++ b/flow-frontend/src/components/ExerciseTracker.tsx
@@ -471,7 +471,8 @@ const ExerciseTracker: React.FC<ExerciseTrackerProps> = ({
           exerciseState.status !== 'completed' &&
           exerciseState.sets_data &&
           exerciseState.sets_data.length > 0 &&
-          activeSetNumber === null && (
+          activeSetNumber === null && 
+          allSetsCompleted && (
             <FormButton
               type="button"
               variant="primary"
@@ -479,7 +480,7 @@ const ExerciseTracker: React.FC<ExerciseTrackerProps> = ({
               isLoading={isSubmitting}
               onClick={handleCompleteExercise}
             >
-              {allSetsCompleted ? 'Update Exercise' : 'Mark Exercise Complete'}
+              Mark Exercise Complete
             </FormButton>
           )}
 

--- a/flow-frontend/src/pages/Dashboard.tsx
+++ b/flow-frontend/src/pages/Dashboard.tsx
@@ -44,7 +44,7 @@ const Dashboard = ({ user, signOut }: DashboardProps) => {
       
       setIsLoadingAthletes(true);
       try {
-        const relationships = await getCoachRelationships(user.user_id);
+        const relationships = await getCoachRelationships(user.user_id, 'active');
         
         // Extract athlete IDs from relationships
         const athletesList = await Promise.all(


### PR DESCRIPTION
**Frontend**

- Fix fetch active coach-athlete relationships instead of pending ones
- Remove Update Exercise button and update to only show Mark Exercise Complete when all sets are marked complete