### PR TITLE
Feature/weight unit system model and services extension

### DIFF
--- a/backend/layers/common/python/src/models/user.py
+++ b/backend/layers/common/python/src/models/user.py
@@ -8,11 +8,15 @@ class User:
         email: str,
         name: str,
         role: Optional[Literal["athlete", "coach"]] = None,
+        weight_unit_preference: Optional[Literal["kg", "lb"]] = "lb",
     ):
         self.user_id: str = user_id
         self.email: str = email
         self.name: str = name
         self.role: Optional[Literal["athlete", "coach"]] = role
+        self.weight_unit_preference: Optional[Literal["kg", "lb"]] = (
+            weight_unit_preference or "lb"
+        )
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -20,4 +24,5 @@ class User:
             "email": self.email,
             "name": self.name,
             "role": self.role,
+            "weight_unit_preference": self.weight_unit_preference,
         }

--- a/backend/layers/common/python/src/services/user_service.py
+++ b/backend/layers/common/python/src/services/user_service.py
@@ -20,19 +20,35 @@ class UserService:
             return User(**user_data)
         return None
 
-    def create_user(self, email: str, name: str, role: Optional[str] = None) -> User:
+    def create_user(
+        self,
+        email: str,
+        name: str,
+        role: Optional[str] = None,
+        weight_unit_preference: Optional[str] = "lb",
+    ) -> User:
         """
-        Creates a new user
+        Creates a new user with optional weight preference
 
         :param email: The email of the user
         :param name: The name of the user
         :param role: The role of the user
+        :param weight_unit_preference: The user's preferred weight unit ('kg' or 'lb')
         :return: The created User object
         """
-        user = User(user_id=str(uuid.uuid4()), email=email, name=name, role=role)
+        # Validate weight unit preference
+        if weight_unit_preference and weight_unit_preference not in ["kg", "lb"]:
+            weight_unit_preference = "lb"
+
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email=email,
+            name=name,
+            role=role,
+            weight_unit_preference=weight_unit_preference,
+        )
 
         self.user_repository.create_user(user.to_dict())
-
         return user
 
     def update_user(self, user_id: str, update_data: Dict[str, Any]) -> Optional[User]:
@@ -43,5 +59,23 @@ class UserService:
         :param update_data: The data to update the user with
         :return: The updated User object if found, else None
         """
+        # Validate weight_unit_preference if it's being updated
+        if "weight_unit_preference" in update_data:
+            weight_pref = update_data["weight_unit_preference"]
+            if weight_pref and weight_pref not in ["kg", "lb"]:
+                update_data["weight_unit_preference"] = "lb"
+
         self.user_repository.update_user(user_id, update_data)
         return self.get_user(user_id)
+
+    def get_user_weight_unit_preference(self, user_id: str) -> str:
+        """
+        Get user's weight unit preference, with fallback to 'lb'
+
+        :param user_id: The ID of the user
+        :return: Weight unit preference ('kg' or 'lb')
+        """
+        user = self.get_user(user_id)
+        if user and user.weight_unit_preference:
+            return user.weight_unit_preference
+        return "lb"

--- a/backend/layers/common/python/src/utils/weight_defaults.py
+++ b/backend/layers/common/python/src/utils/weight_defaults.py
@@ -1,0 +1,14 @@
+POWERLIFTING_EXERCISES = ["squat", "bench press", "deadlift"]
+
+
+def get_default_unit(exercise_type: str, user_preference: str) -> str:
+    """
+    Simple rule: powerlifting = kg, everything else = user preference
+
+    :param exercise_type: Name of the exercise
+    :param user_preference: User's preferred weight unit ('kg' or 'lb')
+    :return: Default weight unit for this exercise
+    """
+    if any(ex in exercise_type.lower() for ex in POWERLIFTING_EXERCISES):
+        return "kg"
+    return user_preference

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -8,11 +8,15 @@ class User:
         email: str,
         name: str,
         role: Optional[Literal["athlete", "coach"]] = None,
+        weight_unit_preference: Optional[Literal["kg", "lb"]] = "lb",
     ):
         self.user_id: str = user_id
         self.email: str = email
         self.name: str = name
         self.role: Optional[Literal["athlete", "coach"]] = role
+        self.weight_unit_preference: Optional[Literal["kg", "lb"]] = (
+            weight_unit_preference or "lb"
+        )
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -20,4 +24,5 @@ class User:
             "email": self.email,
             "name": self.name,
             "role": self.role,
+            "weight_unit_preference": self.weight_unit_preference,
         }

--- a/backend/src/services/user_service.py
+++ b/backend/src/services/user_service.py
@@ -20,19 +20,35 @@ class UserService:
             return User(**user_data)
         return None
 
-    def create_user(self, email: str, name: str, role: Optional[str] = None) -> User:
+    def create_user(
+        self,
+        email: str,
+        name: str,
+        role: Optional[str] = None,
+        weight_unit_preference: Optional[str] = "lb",
+    ) -> User:
         """
-        Creates a new user
+        Creates a new user with optional weight preference
 
         :param email: The email of the user
         :param name: The name of the user
         :param role: The role of the user
+        :param weight_unit_preference: The user's preferred weight unit ('kg' or 'lb')
         :return: The created User object
         """
-        user = User(user_id=str(uuid.uuid4()), email=email, name=name, role=role)
+        # Validate weight unit preference
+        if weight_unit_preference and weight_unit_preference not in ["kg", "lb"]:
+            weight_unit_preference = "lb"
+
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email=email,
+            name=name,
+            role=role,
+            weight_unit_preference=weight_unit_preference,
+        )
 
         self.user_repository.create_user(user.to_dict())
-
         return user
 
     def update_user(self, user_id: str, update_data: Dict[str, Any]) -> Optional[User]:
@@ -43,5 +59,23 @@ class UserService:
         :param update_data: The data to update the user with
         :return: The updated User object if found, else None
         """
+        # Validate weight_unit_preference if it's being updated
+        if "weight_unit_preference" in update_data:
+            weight_pref = update_data["weight_unit_preference"]
+            if weight_pref and weight_pref not in ["kg", "lb"]:
+                update_data["weight_unit_preference"] = "lb"
+
         self.user_repository.update_user(user_id, update_data)
         return self.get_user(user_id)
+
+    def get_user_weight_unit_preference(self, user_id: str) -> str:
+        """
+        Get user's weight unit preference, with fallback to 'lb'
+
+        :param user_id: The ID of the user
+        :return: Weight unit preference ('kg' or 'lb')
+        """
+        user = self.get_user(user_id)
+        if user and user.weight_unit_preference:
+            return user.weight_unit_preference
+        return "lb"

--- a/backend/src/utils/weight_defaults.py
+++ b/backend/src/utils/weight_defaults.py
@@ -1,0 +1,14 @@
+POWERLIFTING_EXERCISES = ["squat", "bench press", "deadlift"]
+
+
+def get_default_unit(exercise_type: str, user_preference: str) -> str:
+    """
+    Simple rule: powerlifting = kg, everything else = user preference
+
+    :param exercise_type: Name of the exercise
+    :param user_preference: User's preferred weight unit ('kg' or 'lb')
+    :return: Default weight unit for this exercise
+    """
+    if any(ex in exercise_type.lower() for ex in POWERLIFTING_EXERCISES):
+        return "kg"
+    return user_preference

--- a/backend/tests/models/test_user.py
+++ b/backend/tests/models/test_user.py
@@ -36,6 +36,51 @@ class TestUserModel(unittest.TestCase):
         self.assertEqual(user.name, "John Doe")
         self.assertEqual(user.role, "coach")
 
+    def test_user_initialization_with_weight_unit_preference(self):
+        """
+        Test User model initialization with weight unit preference
+        """
+        user = User(
+            user_id="user123",
+            email="athlete@example.com",
+            name="Tyler Jones",
+            role="athlete",
+            weight_unit_preference="kg",
+        )
+
+        self.assertEqual(user.user_id, "user123")
+        self.assertEqual(user.email, "athlete@example.com")
+        self.assertEqual(user.name, "Tyler Jones")
+        self.assertEqual(user.role, "athlete")
+        self.assertEqual(user.weight_unit_preference, "kg")
+
+    def test_user_initialization_default_weight_unit_preference(self):
+        """
+        Test User model initialization with default weight unit preference
+        """
+        user = User(
+            user_id="user123",
+            email="athlete@example.com",
+            name="Tyler Jones",
+            role="athlete",
+        )
+
+        self.assertEqual(user.weight_unit_preference, "lb")
+
+    def test_user_initialization_none_weight_unit_preference(self):
+        """
+        Test User model initialization with None weight unit preference defaults to lb
+        """
+        user = User(
+            user_id="user123",
+            email="athlete@example.com",
+            name="Tyler Jones",
+            role="athlete",
+            weight_unit_preference=None,
+        )
+
+        self.assertEqual(user.weight_unit_preference, "lb")
+
     def test_user_to_dict(self):
         """
         Test User model to_dict method
@@ -53,6 +98,30 @@ class TestUserModel(unittest.TestCase):
         self.assertEqual(user_dict["email"], "athlete@example.com")
         self.assertEqual(user_dict["name"], "Tyler Jones")
         self.assertEqual(user_dict["role"], "athlete")
+
+    def test_user_to_dict_includes_weight_unit_preference(self):
+        """
+        Test User model to_dict method includes weight unit preference
+        """
+        user = User(
+            user_id="user123",
+            email="athlete@example.com",
+            name="Tyler Jones",
+            role="athlete",
+            weight_unit_preference="kg",
+        )
+
+        result = user.to_dict()
+
+        expected = {
+            "user_id": "user123",
+            "email": "athlete@example.com",
+            "name": "Tyler Jones",
+            "role": "athlete",
+            "weight_unit_preference": "kg",
+        }
+
+        self.assertEqual(result, expected)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/backend/tests/utils/test_weight_defaults.py
+++ b/backend/tests/utils/test_weight_defaults.py
@@ -1,0 +1,97 @@
+import unittest
+from src.utils.weight_defaults import get_default_unit
+
+
+class TestWeightDefaults(unittest.TestCase):
+    """
+    Test suite for the weight defaults utility functions
+    """
+
+    def test_get_default_unit_powerlifting_squat(self):
+        """
+        Test that squat exercises default to kg
+        """
+        result = get_default_unit("Squat", "lb")
+        self.assertEqual(result, "kg")
+
+    def test_get_default_unit_powerlifting_bench_press(self):
+        """
+        Test that bench press exercises default to kg
+        """
+        result = get_default_unit("Bench Press", "lb")
+        self.assertEqual(result, "kg")
+
+    def test_get_default_unit_powerlifting_deadlift(self):
+        """
+        Test that deadlift exercises default to kg
+        """
+        result = get_default_unit("Deadlift", "lb")
+        self.assertEqual(result, "kg")
+
+    def test_get_default_unit_powerlifting_case_insensitive(self):
+        """
+        Test that powerlifting exercise detection is case insensitive
+        """
+        result = get_default_unit("SQUAT", "lb")
+        self.assertEqual(result, "kg")
+
+        result = get_default_unit("bench press", "lb")
+        self.assertEqual(result, "kg")
+
+    def test_get_default_unit_powerlifting_partial_match(self):
+        """
+        Test that powerlifting exercise detection works with partial matches
+        """
+        result = get_default_unit("Low Bar Squat", "lb")
+        self.assertEqual(result, "kg")
+
+        result = get_default_unit("Romanian Deadlift", "lb")
+        self.assertEqual(result, "kg")
+
+    def test_get_default_unit_non_powerlifting_user_preference_kg(self):
+        """
+        Test that non-powerlifting exercises use user preference (kg)
+        """
+        result = get_default_unit("Bicep Curl", "kg")
+        self.assertEqual(result, "kg")
+
+    def test_get_default_unit_non_powerlifting_user_preference_lb(self):
+        """
+        Test that non-powerlifting exercises use user preference (lb)
+        """
+        result = get_default_unit("Bicep Curl", "lb")
+        self.assertEqual(result, "lb")
+
+    def test_get_default_unit_non_powerlifting_various_exercises(self):
+        """
+        Test various non-powerlifting exercises use user preference
+        """
+        exercises = [
+            "Dumbbell Press",
+            "Pull Ups",
+            "Lat Pulldown",
+            "Leg Extension",
+            "Tricep Pushdown",
+        ]
+
+        for exercise in exercises:
+            with self.subTest(exercise=exercise):
+                result = get_default_unit(exercise, "kg")
+                self.assertEqual(result, "kg")
+
+                result = get_default_unit(exercise, "lb")
+                self.assertEqual(result, "lb")
+
+    def test_get_default_unit_empty_exercise_name(self):
+        """
+        Test that empty exercise name uses user preference
+        """
+        result = get_default_unit("", "kg")
+        self.assertEqual(result, "kg")
+
+        result = get_default_unit("", "lb")
+        self.assertEqual(result, "lb")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add Weight Units System to User and Exercise models

- **User model**:
  - Added weight_unit_preference (“kg”/“lb”), defaulting to “lb.”
  - Validates only “kg” or “lb.”

- **Exercise model**:
  - Removed legacy weight field and replaced it with a single weight_data object ({ value: float, unit: str }).
  - Updated from_dict() to migrate any existing weight values into weight_data.  
  - Utility module:
  - Created src/utils/weight_defaults.py
  - Implements get_default_unit(exercise_type, user_pref)—automatically uses “kg” for powerlifting exercises (“squat,” “bench press,” “deadlift”) and otherwise returns the user’s preference.

- **Service layer**:
  - UserService now persists and validates weight_unit_preference.
  - ExerciseService applies smart defaults via get_default_unit() when weight_data.unit is missing or when tracking sets.

- **Unit tests**:
  - Added/updated tests for user-model validation, exercise-model weight migration, utility logic, and service-layer defaults/overrides.
  - All existing tests updated to reflect new field names and structures; coverage ensures invalid units and negative/edge cases are handled.