### PR TITLE
Feature/versioned layer exports

### DIFF
--- a/backend/app-stack.yaml
+++ b/backend/app-stack.yaml
@@ -14,6 +14,10 @@ Parameters:
     Type: String
     Default: 'https://dev.dykl7ea8q4fpo.amplifyapp.com'
     Description: CORS origin for API Gateway
+  LayerVersion:
+    Type: String
+    Default: v0.1.0
+    Description: Version of layers to use
 
 Globals:
   Function:
@@ -21,8 +25,10 @@ Globals:
     Runtime: python3.9
     MemorySize: 256
     Layers:
-      - !ImportValue flow-layers-VendorLayerArn-us-east-1
-      - !ImportValue flow-layers-CommonLayerArn-us-east-1
+      - !ImportValue 
+        Fn::Sub: "flow-layers-VendorLayerArn-${LayerVersion}"
+      - !ImportValue
+        Fn::Sub: "flow-layers-CommonLayerArn-${LayerVersion}"
     Environment:
       Variables:
         USERS_TABLE: !ImportValue 

--- a/backend/data-stack.yaml
+++ b/backend/data-stack.yaml
@@ -10,6 +10,10 @@ Parameters:
     Default: dev
     AllowedValues: [dev, prod]
     Description: Environment name for resource naming
+  LayerVersion:
+    Type: String
+    Default: v0.1.0
+    Description: Version of layers to use
 
 Resources:
   # Cognito User Pool for Authentication
@@ -261,8 +265,10 @@ Resources:
       Runtime: python3.9
       Timeout: 30
       Layers:
-        - !ImportValue flow-layers-VendorLayerArn-us-east-1
-        - !ImportValue flow-layers-CommonLayerArn-us-east-1
+        - !ImportValue
+          Fn::Sub: "flow-layers-VendorLayerArn-${LayerVersion}"
+        - !ImportValue
+          Fn::Sub: "flow-layers-CommonLayerArn-${LayerVersion}"
       Environment:
         Variables:
           USERS_TABLE: !Ref UsersTable

--- a/backend/layers.yaml
+++ b/backend/layers.yaml
@@ -2,6 +2,12 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: Lambda Layers for Flow App
 
+Parameters:
+  LayerVersion:
+    Type: String
+    Default: v0-1-0
+    Description: Semantic version for layer exports (underscores for CloudFormation compatibility)
+
 Resources:
   VendorLayer:
     Type: AWS::Serverless::LayerVersion
@@ -28,10 +34,10 @@ Outputs:
     Description: ARN for the Vendor Layer
     Value: !Ref VendorLayer
     Export:
-      Name: flow-layers-VendorLayerArn-us-east-1
+      Name: !Sub "flow-layers-VendorLayerArn-${LayerVersion}"
 
   CommonLayerArn:
     Description: ARN for the Common Layer
     Value: !Ref CommonLayer
     Export:
-      Name: flow-layers-CommonLayerArn-us-east-1
+      Name: !Sub "flow-layers-CommonLayerArn-${LayerVersion}"


### PR DESCRIPTION
### Overview
Implements semantic versioning for AWS Lambda layers to eliminate the "delete entire stack" problem and enable clean production deployment. This provides foundation for environment isolation and controlled infrastructure updates.

### Problem Solved

Current Issue: Layer code changes required deleting entire CloudFormation stacks due to immutable export references
Root Cause: AWS auto-generated layer versions (1, 2, 3...) with fixed export names created circular dependencies
Business Impact: Blocked clean production deployment and environment separation

### Solution Implemented

Semantic Versioning: Adopted v0-1-0 format (adapted for CloudFormation export name constraints)
Parameter-Driven Deployment: Added LayerVersion parameter across all stack templates
Controlled Updates: Enables independent layer updates without stack recreation
Environment Ready: Foundation for dev/prod separation

### Technical Details
CloudFormation Export Name Constraints

Discovery: Export names only allow alphanumeric, colons (:), and hyphens (-)
Adaptation: Modified standard semantic versioning (v0.1.0 → v0-1-0) for compliance
Enterprise Approach: Pragmatic solution maintaining semantic meaning within platform limitations

**Files Modified**

backend/layers.yaml - Added LayerVersion parameter and versioned exports
backend/app-stack.yaml - Updated to import versioned layer exports
backend/data-stack.yaml - Updated CognitoPostConfirmationFunction layer references
backend/deploy_sam_stacks.sh - Added layer version parameter support

**Usage Examples**
Default deployment (uses v0-1-0)
./deploy_sam_stacks.sh dev

Explicit version deployment  
./deploy_sam_stacks.sh dev cors_origin v0-2-0

Production deployment (ready for Phase 3)
./deploy_sam_stacks.sh prod prod_cors_origin v1-0-0
Version Update Strategy
