### PR TITLE
fix: Resolve DynamoDB reserved keyword error in date updates

### DIFF
--- a/backend/layers/common/python/src/repositories/block_repository.py
+++ b/backend/layers/common/python/src/repositories/block_repository.py
@@ -72,15 +72,23 @@ class BlockRepository(BaseRepository):
         """
         update_expression = "set "
         expression_values = {}
+        expression_attribute_names = {}
 
         for key, value in update_dict.items():
-            update_expression += f"{key} = :{key}, "
+            attr_name = f"#{key}"
+            expression_attribute_names[attr_name] = key
+            update_expression += f"{attr_name} = :{key}, "
             expression_values[f":{key}"] = value
 
         # Remove trailing comma and space
         update_expression = update_expression[:-2]
 
-        return self.update({"block_id": block_id}, update_expression, expression_values)
+        return self.update(
+            {"block_id": block_id},
+            update_expression,
+            expression_values,
+            expression_attribute_names,
+        )
 
     def delete_block(self, block_id: str) -> Dict[str, Any]:
         """

--- a/backend/src/repositories/block_repository.py
+++ b/backend/src/repositories/block_repository.py
@@ -72,15 +72,23 @@ class BlockRepository(BaseRepository):
         """
         update_expression = "set "
         expression_values = {}
+        expression_attribute_names = {}
 
         for key, value in update_dict.items():
-            update_expression += f"{key} = :{key}, "
+            attr_name = f"#{key}"
+            expression_attribute_names[attr_name] = key
+            update_expression += f"{attr_name} = :{key}, "
             expression_values[f":{key}"] = value
 
         # Remove trailing comma and space
         update_expression = update_expression[:-2]
 
-        return self.update({"block_id": block_id}, update_expression, expression_values)
+        return self.update(
+            {"block_id": block_id},
+            update_expression,
+            expression_values,
+            expression_attribute_names,
+        )
 
     def delete_block(self, block_id: str) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Fix: Block Date Editing Persistence Issue

### Problem
Users could not edit program start dates - changes would not persist and resulted in 500 errors.

### Root Cause
DynamoDB `UpdateItem` operation failed because `status` is a reserved keyword. The `block_repository.py` was missing `expression_attribute_names` to handle reserved keywords properly.

### Solution
- Added `expression_attribute_names` parameter to `update_block` method
- Used `#` prefix syntax for attribute names to avoid reserved keyword conflicts
- Matches the pattern already implemented in `exercise_repository.py`

### Testing
- Block date editing now persists correctly
- No 500 errors on form submission
- Dates display correctly after save

### Files Changed
- `backend/src/repositories/block_repository.py` - Added reserved keyword handling

### Impact
Resolves critical workflow blocker for program management.