### PR TITLE
fix: Enable horizontal scroll for week navigation on mobile

### DIFF
--- a/flow-frontend/src/pages/BlockDetail.tsx
+++ b/flow-frontend/src/pages/BlockDetail.tsx
@@ -395,7 +395,7 @@ const BlockDetail = ({ user, signOut }: BlockDetailProps) => {
             {weeks.length > 0 ? (
               <div className="bg-white shadow rounded-lg overflow-hidden">
                 <div className="border-b border-gray-200">
-                  <nav className="flex">
+                  <nav className="flex overflow-x-auto">
                     {weeks.map((week) => (
                       <button
                         key={week.week_id}


### PR DESCRIPTION
### Frontend
- Add overflow-x-auto to week tabs container
- Fixes mobile access to programs with >5 weeks
- Resolves H2 priority issue from production roadmap