### PR TITLE
feat: Implement inline set editing & removed modal-based tracking

### DIFF
--- a/flow-frontend/src/components/ExerciseTracker.tsx
+++ b/flow-frontend/src/components/ExerciseTracker.tsx
@@ -17,14 +17,15 @@ import {
 import { trackExerciseSet, deleteSet, completeExercise, reorderExerciseSets } from '../services/api';
 import type { Exercise, ExerciseSetData } from '../services/api';
 import FormButton from './FormButton';
+import SortableInlineSetRow from './SortableInlineSetRow';
 import { useWeightUnit } from '../contexts/UserContext';
-import SortableSetButton from './SortableSetButton';
 
 interface ExerciseTrackerProps {
   exercise: Exercise;
   onComplete: () => void;
   onCancel?: () => void;
   readOnly?: boolean;
+  forceExpanded?: boolean;
 }
 
 const ExerciseTracker: React.FC<ExerciseTrackerProps> = ({
@@ -32,22 +33,37 @@ const ExerciseTracker: React.FC<ExerciseTrackerProps> = ({
   onComplete,
   onCancel,
   readOnly = false,
+  forceExpanded = false, // Default to false for backward compatibility
 }) => {
   const [exerciseState, setExerciseState] = useState<Exercise>(exercise);
-  const [activeSetNumber, setActiveSetNumber] = useState<number | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [showCompleteConfirm, setShowCompleteConfirm] = useState(false);
-  const [setData, setSetData] = useState({
-    reps: exercise.reps || 0,
-    weight: exercise.weight || 0,
-    rpe: undefined as number | undefined,
-    notes: '',
+  
+  //  Conditional expansion state - only used when NOT force expanded
+  const [isExpanded, setIsExpanded] = useState(() => {
+    if (forceExpanded) return true; // Always expanded when forced
+    
+    // Remember expansion state per exercise (existing logic)
+    const savedState = localStorage.getItem(`exercise-expanded-${exercise.exercise_id}`);
+    return savedState ? JSON.parse(savedState) : false;
   });
+
   const { getDisplayUnit } = useWeightUnit();
   const displayUnit = getDisplayUnit(exercise.exercise_type);
 
-  // Add drag-and-drop sensors
+  // Update exercise state when prop changes
+  useEffect(() => {
+    setExerciseState(exercise);
+  }, [exercise]);
+
+  //  Only save expansion state if NOT force expanded
+  useEffect(() => {
+    if (!forceExpanded) {
+      localStorage.setItem(`exercise-expanded-${exerciseState.exercise_id}`, JSON.stringify(isExpanded));
+    }
+  }, [isExpanded, exerciseState.exercise_id, forceExpanded]);
+
+  // Add drag-and-drop sensors (keeping existing functionality)
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, {
@@ -55,7 +71,31 @@ const ExerciseTracker: React.FC<ExerciseTrackerProps> = ({
     })
   );
 
-  // Handle drag end
+  // Generate array of set numbers
+  const sets = Array.from({ length: exerciseState.sets }, (_, i) => i + 1);
+
+  // Map existing set data by set number for quick lookup
+  const setsDataMap = (exerciseState.sets_data || []).reduce((map, setData) => {
+    if (setData && typeof setData.set_number === 'number') {
+      map[setData.set_number] = setData;
+    }
+    return map;
+  }, {} as Record<number, ExerciseSetData>);
+
+  // Calculate completion status
+  const completedSets = exerciseState.sets_data?.filter(set => set.completed).length || 0;
+  const allSetsCompleted = completedSets >= exerciseState.sets && exerciseState.sets > 0;
+  const progressPercentage = exerciseState.sets > 0 ? (completedSets / exerciseState.sets) * 100 : 0;
+
+  // Get previous set data for auto-population
+  const getPreviousSetData = (currentSetNumber: number): ExerciseSetData | undefined => {
+    if (currentSetNumber === 1) {
+      return undefined; // First set has no previous
+    }
+    return setsDataMap[currentSetNumber - 1];
+  };
+
+  // Handle drag end for set reordering
   const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event;
 
@@ -64,18 +104,14 @@ const ExerciseTracker: React.FC<ExerciseTrackerProps> = ({
       const newIndex = sets.findIndex(setNum => setNum === over?.id);
 
       if (oldIndex !== -1 && newIndex !== -1) {
-        // Create new order array
         const newOrder = arrayMove(sets, oldIndex, newIndex);
         
         try {
           setIsSubmitting(true);
           setError(null);
           
-          // Send reorder request to backend
           await reorderExerciseSets(exerciseState.exercise_id, newOrder);
-          
-          // Refresh exercise data
-          onComplete();
+          onComplete(); // Refresh exercise data
         } catch (err: any) {
           console.error('Error reordering sets:', err);
           setError('Failed to reorder sets. Please try again.');
@@ -86,126 +122,29 @@ const ExerciseTracker: React.FC<ExerciseTrackerProps> = ({
     }
   };
 
-  useEffect(() => {
-    setExerciseState(exercise);
-  }, [exercise]);
-
-  const actualSets = Math.max(1, exerciseState.sets || 1);
-  const sets = Array.from({ length: actualSets }, (_, i) => i + 1);
-
-  const [allSetsCompleted, setAllSetsCompleted] = useState(false);
-  const setsDataMap = (exerciseState.sets_data || []).reduce(
-    (map, setData) => {
-      if (setData && typeof setData.set_number === 'number') {
-        map[setData.set_number] = setData;
-      }
-      return map;
-    },
-    {} as Record<number, ExerciseSetData>,
-  );
-
-  const completedSets = Object.values(setsDataMap).filter((set) => set.completed).length;
-  const completionPercentage = sets.length > 0 ? (completedSets / sets.length) * 100 : 0;
-
-  useEffect(() => {
-    if (exerciseState.sets_data && exerciseState.sets_data.length > 0) {
-      setAllSetsCompleted(completedSets >= exerciseState.sets);
-    } else {
-      setAllSetsCompleted(false);
-    }
-  }, [exerciseState.sets_data, exerciseState.sets, completedSets]);
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target;
-    setSetData((prev) => ({
-      ...prev,
-      [name]: name === 'notes' ? value : Number(value) || 0,
-    }));
-  };
-
-  const selectSet = (setNumber: number) => {
-    if (readOnly) return;
-
-    if (setsDataMap[setNumber]) {
-      const existingData = setsDataMap[setNumber];
-      setSetData({
-        reps: existingData.reps || exerciseState.reps,
-        weight: existingData.weight || exerciseState.weight,
-        rpe: existingData.rpe,
-        notes: existingData.notes || '',
-      });
-    } else {
-      setSetData({
-        reps: exerciseState.reps,
-        weight: exerciseState.weight,
-        rpe: undefined,
-        notes: '',
-      });
-    }
-    setActiveSetNumber(setNumber);
-    setError(null);
-  };
-
-  const handleSubmitSet = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (activeSetNumber === null || readOnly) return;
-
-    setIsSubmitting(true);
-    setError(null);
-
-    try {
-      if (setData.reps <= 0) throw new Error('Reps must be greater than zero');
-      if (setData.weight < 0) throw new Error('Weight cannot be negative');
-      if (setData.rpe !== undefined && (setData.rpe < 0 || setData.rpe > 10)) {
-        throw new Error('RPE must be between 0 and 10');
-      }
-
-      await trackExerciseSet(exerciseState.exercise_id, activeSetNumber, {
-        reps: setData.reps,
-        weight: setData.weight,
-        rpe: setData.rpe,
-        completed: true,
-        notes: setData.notes || undefined,
-      });
-
-      setActiveSetNumber(null);
-      onComplete();
-    } catch (err: any) {
-      setError(err.message || 'Failed to log set');
-      console.error('Error logging set:', err);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
   const addSet = async () => {
     if (readOnly) return;
     setIsSubmitting(true);
     setError(null);
 
     try {
-      // Calculate new set count
       const newSetCount = exerciseState.sets + 1;
-
+      
       // Update local state immediately for better UX
       setExerciseState((prev) => ({ ...prev, sets: newSetCount }));
 
-      // Instead of using updateExercise, create a "placeholder" set
-      // This implicitly creates the new set and updates the exercise
+      // Create placeholder set
       await trackExerciseSet(exerciseState.exercise_id, newSetCount, {
         reps: exerciseState.reps,
         weight: exerciseState.weight,
-        // Only include RPE if it exists
         ...(exerciseState.rpe !== undefined && { rpe: exerciseState.rpe }),
-        completed: false, // Mark as not completed yet
+        completed: false,
       });
 
-      // Refresh from server
-      onComplete();
+      onComplete(); // Refresh from server
     } catch (err) {
       console.error('Error adding set:', err);
-      // Revert local state on error
-      setExerciseState((prev) => ({ ...prev, sets: prev.sets - 1 }));
+      setExerciseState((prev) => ({ ...prev, sets: prev.sets })); // Revert on error
       setError('Failed to add set. Please try again.');
     } finally {
       setIsSubmitting(false);
@@ -213,24 +152,15 @@ const ExerciseTracker: React.FC<ExerciseTrackerProps> = ({
   };
 
   const removeSet = async (setNumber: number) => {
-    if (readOnly || sets.length <= 1) return;
+    if (readOnly || exerciseState.sets <= 1) return;
+    
     setIsSubmitting(true);
     setError(null);
 
     try {
-      const existingSetData = setsDataMap[setNumber];
-      if (existingSetData) {
-        await deleteSet(exerciseState.exercise_id, setNumber);
-      }
-
-      if (activeSetNumber === setNumber) setActiveSetNumber(null);
-      const currentActiveSet = activeSetNumber;
-      onComplete();
-
-      if (currentActiveSet && currentActiveSet !== setNumber) {
-        setTimeout(() => setActiveSetNumber(currentActiveSet), 100);
-      }
-    } catch (err) {
+      await deleteSet(exerciseState.exercise_id, setNumber);
+      onComplete(); // Refresh exercise data
+    } catch (err: any) {
       console.error('Error removing set:', err);
       setError('Failed to remove set. Please try again.');
     } finally {
@@ -239,318 +169,208 @@ const ExerciseTracker: React.FC<ExerciseTrackerProps> = ({
   };
 
   const handleCompleteExercise = async () => {
-    // First show confirmation dialog
-    if (!showCompleteConfirm) {
-      const totalSets = exerciseState.sets || 1;
-      const completedSetsCount =
-        exerciseState.sets_data?.filter((set) => set.completed).length || 0;
-
-      if (completedSetsCount < totalSets) {
-        setError(
-          `You've completed ${completedSetsCount} out of ${totalSets} planned sets. Are you sure you want to mark this exercise as complete?`,
-        );
-      }
-      setShowCompleteConfirm(true);
-      return;
-    }
-
-    // If confirmed, proceed with completion
     if (readOnly) return;
+    
     setIsSubmitting(true);
     setError(null);
-    setShowCompleteConfirm(false);
 
     try {
-      const trackedSets = exerciseState.sets_data?.filter((set) => set.completed) || [];
-
-      if (trackedSets.length === 0) {
-        setError('Please complete at least one set before marking the exercise as completed.');
-        setIsSubmitting(false);
-        return;
-      }
-
-      // Keep the original planned sets count, not just completed ones
       await completeExercise(exerciseState.exercise_id, {
-        sets: exerciseState.sets, // Use original sets count
+        sets: exerciseState.sets,
         reps: exerciseState.reps,
         weight: exerciseState.weight,
         rpe: exerciseState.rpe,
         notes: exerciseState.notes,
       });
-
       onComplete();
     } catch (err: any) {
       console.error('Error completing exercise:', err);
-      setError(err.message || 'Failed to complete exercise');
+      setError('Failed to complete exercise. Please try again.');
     } finally {
       setIsSubmitting(false);
     }
   };
 
+  // Determine if content should be shown (force expanded OR user expanded)
+  const shouldShowContent = forceExpanded || isExpanded;
+
   return (
-    <div className="space-y-6">
-      {error && (
-        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
-          {error}
-        </div>
-      )}
-
-      {/* Progress Bar */}
-      <div className="mb-4">
-        <div className="w-full bg-gray-200 rounded-full h-2.5">
-          <div
-            className="bg-green-600 h-2.5 rounded-full"
-            style={{ width: `${completionPercentage}%` }}
-          ></div>
-        </div>
-        <div className="mt-1 flex justify-between text-xs text-gray-500">
-          <span>
-            {completedSets} of {sets.length} sets completed
-          </span>
-          <span>{Math.round(completionPercentage)}%</span>
-        </div>
-      </div>
-
-      {/* Set Buttons */}
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-      >
-        <div className="flex flex-wrap gap-2 mb-4">
-          <SortableContext items={sets} strategy={verticalListSortingStrategy}>
-            {sets.map((setNumber) => {
-              const isCompleted = setsDataMap[setNumber]?.completed;
-              const isActive = activeSetNumber === setNumber;
-
-              return (
-                <SortableSetButton
-                  key={setNumber}
-                  setNumber={setNumber}
-                  isCompleted={isCompleted}
-                  isActive={isActive}
-                  onSelect={selectSet}
-                  onRemove={removeSet}
-                  canRemove={sets.length > 1}
-                  readOnly={readOnly}
+    <div className="space-y-4">
+      {/* Conditionally render header - only show when NOT force expanded */}
+      {!forceExpanded && (
+        <div 
+          className="flex justify-between items-start cursor-pointer hover:bg-gray-50 p-2 rounded-lg transition-colors"
+          onClick={() => setIsExpanded(!isExpanded)}
+        >
+          <div className="flex-1">
+            <div className="flex items-center space-x-2">
+              <h3 className="text-lg font-semibold text-gray-900">{exerciseState.exercise_type}</h3>
+              {/* Exercise completion visual indicator */}
+              {exerciseState.status === 'completed' && (
+                <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                  ✓ Complete
+                </span>
+              )}
+            </div>
+            <p className="text-sm text-gray-600">
+              {exerciseState.sets} sets × {exerciseState.reps} reps @ {exerciseState.weight}{displayUnit}
+              {exerciseState.rpe && ` @ RPE ${exerciseState.rpe}`}
+            </p>
+          </div>
+          
+          {/* Progress indicator with chevron */}
+          <div className="flex items-center space-x-3">
+            <div className="text-right">
+              <div className="text-sm font-medium text-gray-700">
+                {completedSets}/{exerciseState.sets} sets
+              </div>
+              <div className="w-20 h-2 bg-gray-200 rounded-full mt-1">
+                <div
+                  className="h-2 bg-blue-500 rounded-full transition-all"
+                  style={{ width: `${progressPercentage}%` }}
                 />
-              );
-            })}
-          </SortableContext>
-
-          {/* Add set button */}
-          {!readOnly && (
-            <button
-              onClick={addSet}
-              disabled={isSubmitting}
-              className="w-12 h-12 rounded-full flex items-center justify-center font-medium bg-blue-50 text-blue-600 border-2 border-dashed border-blue-300 hover:bg-blue-100 disabled:opacity-50"
-              title="Add set"
-            >
-              <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 6v6m0 0v6m0-6h6m-6 0H6"
-                />
+              </div>
+            </div>
+            
+            {/* Chevron indicator */}
+            <div className="flex items-center">
+              <svg 
+                className={`w-5 h-5 text-gray-400 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+                fill="none" 
+                stroke="currentColor" 
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
-            </button>
-          )}
+            </div>
+          </div>
         </div>
-      </DndContext>
-
-      {/* Set Form */}
-      {activeSetNumber !== null && !readOnly && (
-        <form onSubmit={handleSubmitSet} className="border rounded-lg p-4 bg-gray-50 space-y-4">
-          <div className="flex justify-between items-center mb-2">
-            <h4 className="font-medium text-gray-700">Set {activeSetNumber}</h4>
-            {setsDataMap[activeSetNumber]?.completed && (
-              <span className="text-xs px-2 py-1 bg-green-100 text-green-800 rounded-full">
-                Completed
-              </span>
-            )}
-          </div>
-
-          <div className="grid grid-cols-3 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Reps</label>
-              <input
-                type="number"
-                name="reps"
-                value={setData.reps}
-                onChange={handleInputChange}
-                className="w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                min="1"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">{displayUnit}</label>
-              <input
-                type="number"
-                name="weight"
-                value={setData.weight}
-                onChange={handleInputChange}
-                className="w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                min="0"
-                step="0.5"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">RPE</label>
-              <input
-                type="number"
-                name="rpe"
-                value={setData.rpe || ''}
-                onChange={handleInputChange}
-                className="w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                placeholder="0-10"
-                min="0"
-                max="10"
-                step="0.5"
-              />
-            </div>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Notes</label>
-            <textarea
-              name="notes"
-              value={setData.notes}
-              onChange={handleInputChange}
-              rows={2}
-              className="w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500"
-              placeholder="Optional notes about this set"
-            />
-          </div>
-
-          <div className="flex justify-between">
-            <FormButton type="button" variant="secondary" onClick={() => setActiveSetNumber(null)}>
-              Cancel
-            </FormButton>
-            <FormButton type="submit" variant="primary" isLoading={isSubmitting}>
-              {setsDataMap[activeSetNumber]?.completed ? 'Update Set' : 'Complete Set'}
-            </FormButton>
-          </div>
-        </form>
       )}
 
-      {/* Sets Table */}
-      {activeSetNumber === null &&
-        exerciseState.sets_data &&
-        exerciseState.sets_data.length > 0 && (
-          <div className="mt-2">
-            <h4 className="text-sm font-medium text-gray-500 mb-2">Completed Sets</h4>
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Set
-                    </th>
-                    <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Reps
-                    </th>
-                    <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      {displayUnit}
-                    </th>
-                    <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      RPE
-                    </th>
-                    <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Notes
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="bg-white divide-y divide-gray-200">
-                  {Object.values(setsDataMap)
-                    .filter((setData) => setData && typeof setData.set_number === 'number')
-                    .sort((a, b) => (a.set_number || 0) - (b.set_number || 0))
-                    .map((setData) => (
-                      <tr
-                        key={setData.set_number}
-                        className={`hover:bg-gray-50 ${!readOnly ? 'cursor-pointer' : ''}`}
-                        onClick={() =>
-                          !readOnly &&
-                          setData &&
-                          typeof setData.set_number === 'number' &&
-                          selectSet(setData.set_number)
-                        }
-                      >
-                        <td className="px-3 py-2 whitespace-nowrap text-sm">
-                          {setData.set_number}
-                        </td>
-                        <td className="px-3 py-2 whitespace-nowrap text-sm">{setData.reps}</td>
-                        <td className="px-3 py-2 whitespace-nowrap text-sm">{setData.weight}</td>
-                        <td className="px-3 py-2 whitespace-nowrap text-sm">
-                          {setData.rpe || '-'}
-                        </td>
-                        <td className="px-3 py-2 whitespace-nowrap text-sm">
-                          {setData.notes || '-'}
-                        </td>
-                      </tr>
-                    ))}
-                </tbody>
-              </table>
+      {/* Conditionally render expanded content - show if force expanded OR user expanded */}
+      {shouldShowContent && (
+        <>
+          {/* Error display */}
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-md p-3">
+              <p className="text-sm text-red-700">{error}</p>
             </div>
-          </div>
-        )}
-
-      {/* Empty state message */}
-      {activeSetNumber === null &&
-        (!exerciseState.sets_data || exerciseState.sets_data.length === 0) && (
-          <div className="text-center py-4 text-gray-500">
-            <p className="mb-2">No sets tracked yet</p>
-            {!readOnly && (
-              <p className="text-sm">Click on a set number above to log your set data</p>
-            )}
-          </div>
-        )}
-
-      {/* Action Buttons */}
-      <div className="flex justify-between mt-4 pt-3 border-t">
-        {/* Show Complete button only for non-completed exercises */}
-        {!readOnly &&
-          exerciseState.status !== 'completed' &&
-          exerciseState.sets_data &&
-          exerciseState.sets_data.length > 0 &&
-          activeSetNumber === null && 
-          allSetsCompleted && (
-            <FormButton
-              type="button"
-              variant="primary"
-              disabled={isSubmitting}
-              isLoading={isSubmitting}
-              onClick={handleCompleteExercise}
-            >
-              Mark Exercise Complete
-            </FormButton>
           )}
 
-        {/* Add Set button - only visible for non-completed exercises */}
-        {!readOnly && exerciseState.status !== 'completed' && activeSetNumber === null && (
-          <button
-            onClick={addSet}
-            className="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-blue-600 bg-blue-100 hover:bg-blue-200"
-          >
-            <svg className="h-5 w-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 6v6m0 0v6m0-6h6m-6 0H6"
-              />
-            </svg>
-            Add Set
-          </button>
-        )}
+          {/* Sets Table - Always visible when expanded */}
+          <div className="border border-gray-200 rounded-lg overflow-hidden">
+            <table className="w-full">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-2 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider w-8">
+                    {/* Drag handle column */}
+                  </th>
+                  <th className="px-2 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider w-12">
+                    Set
+                  </th>
+                  <th className="px-2 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider w-20">
+                    {displayUnit}
+                  </th>
+                  <th className="px-2 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider w-16">
+                    Reps
+                  </th>
+                  <th className="px-2 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider w-16">
+                    RPE
+                  </th>
+                  <th className="px-2 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider w-16">
+                    Notes
+                  </th>
+                  <th className="px-2 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider w-12">
+                    ✓
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragEnd={handleDragEnd}
+                >
+                  <SortableContext items={sets} strategy={verticalListSortingStrategy}>
+                    {sets.map((setNumber) => (
+                      <SortableInlineSetRow
+                        key={setNumber}
+                        exerciseId={exerciseState.exercise_id}
+                        setNumber={setNumber}
+                        existingData={setsDataMap[setNumber]}
+                        previousSetData={getPreviousSetData(setNumber)}
+                        plannedReps={exerciseState.reps}
+                        plannedWeight={exerciseState.weight}
+                        readOnly={readOnly}
+                        onSetUpdated={onComplete}
+                      />
+                    ))}
+                  </SortableContext>
+                </DndContext>
+              </tbody>
+            </table>
+          </div>
 
-        {/* Cancel button */}
-        {activeSetNumber === null && onCancel && (
-          <FormButton type="button" variant="secondary" onClick={onCancel}>
-            Close
-          </FormButton>
-        )}
-      </div>
+          {/* Action Buttons - Always visible when expanded */}
+          <div className="flex justify-between items-center">
+            <div className="flex space-x-2">
+              {/* Add Set Button */}
+              {!readOnly && (
+                <FormButton
+                  type="button"
+                  variant="secondary"
+                  onClick={addSet}
+                  disabled={isSubmitting}
+                  isLoading={isSubmitting}
+                >
+                  Add Set
+                </FormButton>
+              )}
+
+              {/* Remove Last Set Button */}
+              {!readOnly && exerciseState.sets > 1 && (
+                <FormButton
+                  type="button"
+                  variant="secondary"
+                  onClick={() => removeSet(exerciseState.sets)}
+                  disabled={isSubmitting}
+                  className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                >
+                  Remove Last Set
+                </FormButton>
+              )}
+            </div>
+
+            <div className="flex space-x-2">
+              {/* Complete Exercise Button */}
+              {!readOnly && 
+                exerciseState.status !== 'completed' && 
+                allSetsCompleted && (
+                <FormButton
+                  type="button"
+                  variant="primary"
+                  onClick={handleCompleteExercise}
+                  disabled={isSubmitting}
+                  isLoading={isSubmitting}
+                >
+                  Complete Exercise
+                </FormButton>
+              )}
+
+              {/* Cancel Button */}
+              {onCancel && (
+                <FormButton
+                  type="button"
+                  variant="secondary"
+                  onClick={onCancel}
+                >
+                  Cancel
+                </FormButton>
+              )}
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/flow-frontend/src/components/SortableInlineSetRow.tsx
+++ b/flow-frontend/src/components/SortableInlineSetRow.tsx
@@ -1,0 +1,391 @@
+import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { ExerciseSetData } from '../services/api';
+
+interface SortableInlineSetRowProps {
+  exerciseId: string;
+  setNumber: number;
+  existingData?: ExerciseSetData;
+  previousSetData?: ExerciseSetData;
+  plannedReps: number;
+  plannedWeight: number;
+  readOnly?: boolean;
+  onSetUpdated: () => void;
+}
+
+const SortableInlineSetRow: React.FC<SortableInlineSetRowProps> = (props) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: props.setNumber,
+    disabled: props.readOnly,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 1000 : 'auto',
+  };
+
+  return (
+    <tr
+      ref={setNodeRef}
+      style={style}
+      className={`border-b hover:bg-gray-50 ${isDragging ? 'opacity-75 bg-blue-50' : ''}`}
+    >
+      {/* Drag Handle Column */}
+      <td className="px-2 py-3 text-center w-8">
+        <div
+          {...attributes}
+          {...listeners}
+          className={`cursor-grab active:cursor-grabbing p-1 rounded hover:bg-gray-200 transition-colors ${
+            props.readOnly ? 'cursor-not-allowed opacity-50' : ''
+          }`}
+          title={props.readOnly ? 'Cannot reorder' : 'Drag to reorder'}
+        >
+          <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8h16M4 16h16" />
+          </svg>
+        </div>
+      </td>
+
+      {/* Inline Set Row Content */}
+      <InlineSetRowContent {...props} />
+    </tr>
+  );
+};
+
+// Extract the content part of InlineSetRow (without the <tr> wrapper)
+const InlineSetRowContent: React.FC<SortableInlineSetRowProps> = ({
+  exerciseId,
+  setNumber,
+  existingData,
+  previousSetData,
+  plannedReps,
+  plannedWeight,
+  readOnly = false,
+  onSetUpdated,
+}) => {
+  // Copy all the logic from InlineSetRow.tsx but render only the <td> elements
+  const [isEditing, setIsEditing] = React.useState(false);
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [notesExpanded, setNotesExpanded] = React.useState(false);
+  
+  // Local state for form data
+  const [formData, setFormData] = React.useState<{
+    reps: number;
+    weight: number;
+    rpe: number | undefined;
+    notes: string;
+  }>({
+    reps: existingData?.reps ?? plannedReps,
+    weight: existingData?.weight ?? plannedWeight,
+    rpe: existingData?.rpe ?? undefined,
+    notes: existingData?.notes ?? '',
+  });
+
+  // Refs for auto-focus management
+  const repsRef = React.useRef<HTMLInputElement>(null);
+  const weightRef = React.useRef<HTMLInputElement>(null);
+  const rpeRef = React.useRef<HTMLInputElement>(null);
+  const notesRef = React.useRef<HTMLTextAreaElement>(null);
+
+  // Auto-populate from previous set when creating new set
+  React.useEffect(() => {
+    if (!existingData && previousSetData) {
+      setFormData({
+        reps: previousSetData.reps,
+        weight: previousSetData.weight,
+        rpe: previousSetData.rpe,
+        notes: '', // Don't copy notes from previous set
+      });
+    }
+  }, [existingData, previousSetData]);
+
+  const isCompleted = existingData?.completed ?? false;
+
+  // Copy all the handler functions from InlineSetRow.tsx
+  const handleInputChange = (field: keyof typeof formData, value: string | number | undefined) => {
+    // Handle empty string inputs for numeric fields
+    if (field === 'reps' || field === 'weight') {
+      if (value === '' || value === null) {
+        setFormData(prev => ({
+          ...prev,
+          [field]: field === 'reps' ? 1 : 0, // reps defaults to 1, weight to 0
+        }));
+      } else {
+        setFormData(prev => ({
+          ...prev,
+          [field]: Number(value),
+        }));
+      }
+    } else if (field === 'rpe') {
+      if (value === '' || value === null) {
+        setFormData(prev => ({
+          ...prev,
+          rpe: undefined,
+        }));
+      } else {
+        setFormData(prev => ({
+          ...prev,
+          rpe: Number(value),
+        }));
+      }
+    } else if (field === 'notes') {
+      setFormData(prev => ({
+        ...prev,
+        notes: String(value || ''),
+      }));
+    }
+    setError(null);
+  };
+
+  const validateData = () => {
+    if (formData.reps <= 0) {
+      throw new Error('Reps must be greater than zero');
+    }
+    if (formData.weight < 0) {
+      throw new Error('Weight cannot be negative');
+    }
+    if (formData.rpe !== undefined && (formData.rpe < 0 || formData.rpe > 10)) {
+      throw new Error('RPE must be between 0 and 10');
+    }
+  };
+
+  const handleToggleCompletion = async () => {
+    if (readOnly || isSaving) return;
+    
+    try {
+      setIsSaving(true);
+      setError(null);
+
+      if (isCompleted) {
+        // Mark as incomplete
+        await import('../services/api').then(({ trackExerciseSet }) =>
+          trackExerciseSet(exerciseId, setNumber, {
+            reps: formData.reps,
+            weight: formData.weight,
+            rpe: formData.rpe || undefined,
+            completed: false,
+            notes: formData.notes || undefined,
+          })
+        );
+      } else {
+        // Mark as complete - validate data first
+        validateData();
+        await import('../services/api').then(({ trackExerciseSet }) =>
+          trackExerciseSet(exerciseId, setNumber, {
+            reps: formData.reps,
+            weight: formData.weight,
+            rpe: formData.rpe || undefined,
+            completed: true,
+            notes: formData.notes || undefined,
+          })
+        );
+      }
+
+      onSetUpdated();
+    } catch (err: any) {
+      setError(err.message || 'Failed to update set completion');
+      console.error('Error toggling completion:', err);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleCellClick = (field: 'reps' | 'weight' | 'rpe') => {
+    if (readOnly) return;
+    setIsEditing(true);
+    
+    // Focus appropriate input after state update
+    setTimeout(() => {
+      if (field === 'reps' && repsRef.current) repsRef.current.focus();
+      if (field === 'weight' && weightRef.current) weightRef.current.focus();
+      if (field === 'rpe' && rpeRef.current) rpeRef.current.focus();
+    }, 0);
+  };
+
+  const handleBlur = async (e: React.FocusEvent) => {
+    const relatedTarget = e.relatedTarget as HTMLElement;
+    const currentRow = e.currentTarget.closest('tr');
+    const targetInSameRow = relatedTarget && currentRow?.contains(relatedTarget);
+    
+    if (targetInSameRow) {
+      return;
+    }
+
+    setIsEditing(false);
+  };
+
+  const toggleNotes = () => {
+    setNotesExpanded(!notesExpanded);
+    if (!notesExpanded && notesRef.current) {
+      setTimeout(() => notesRef.current?.focus(), 0);
+    }
+  };
+
+  return (
+    <>
+      {/* Set Number */}
+      <td className="px-2 py-3 text-center font-medium w-12">
+        <div className="flex items-center justify-center">
+          <span className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium ${
+            isCompleted 
+              ? 'bg-green-100 text-green-800' 
+              : 'bg-gray-100 text-gray-600'
+          }`}>
+            {setNumber}
+          </span>
+        </div>
+      </td>
+
+      {/* Weight */}
+      <td className="px-2 py-3 w-20" onClick={() => handleCellClick('weight')}>
+        {isEditing ? (
+          <input
+            ref={weightRef}
+            type="number"
+            value={formData.weight}
+            onChange={(e) => handleInputChange('weight', Number(e.target.value) || 0)}
+            onBlur={handleBlur}
+            className="w-full px-2 py-1 text-sm border border-blue-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+            min="0"
+            step="0.5"
+            disabled={isSaving}
+          />
+        ) : (
+          <div className="px-2 py-1 text-sm cursor-text hover:bg-gray-100 rounded">
+            {formData.weight}
+          </div>
+        )}
+      </td>
+
+      {/* Reps */}
+      <td className="px-2 py-3 w-16" onClick={() => handleCellClick('reps')}>
+        {isEditing ? (
+          <input
+            ref={repsRef}
+            type="number"
+            value={formData.reps}
+            onChange={(e) => handleInputChange('reps', Number(e.target.value) || 0)}
+            onBlur={handleBlur}
+            className="w-full px-2 py-1 text-sm border border-blue-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+            min="1"
+            disabled={isSaving}
+          />
+        ) : (
+          <div className="px-2 py-1 text-sm cursor-text hover:bg-gray-100 rounded">
+            {formData.reps}
+          </div>
+        )}
+      </td>
+
+      {/* RPE */}
+      <td className="px-2 py-3 w-16" onClick={() => handleCellClick('rpe')}>
+        {isEditing ? (
+          <input
+            ref={rpeRef}
+            type="number"
+            value={formData.rpe || ''}
+            onChange={(e) => handleInputChange('rpe', Number(e.target.value) || undefined)}
+            onBlur={handleBlur}
+            className="w-full px-2 py-1 text-sm border border-blue-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+            min="0"
+            max="10"
+            step="0.5"
+            placeholder="0-10"
+            disabled={isSaving}
+          />
+        ) : (
+          <div className="px-2 py-1 text-sm cursor-text hover:bg-gray-100 rounded">
+            {formData.rpe || '-'}
+          </div>
+        )}
+      </td>
+
+      {/* Notes */}
+      <td className="px-2 py-3 w-16">
+        <button
+          onClick={toggleNotes}
+          className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${
+            formData.notes 
+              ? 'bg-blue-100 text-blue-600' 
+              : 'bg-gray-100 text-gray-400 hover:bg-gray-200'
+          }`}
+          title={formData.notes ? 'View notes' : 'Add notes'}
+          disabled={readOnly}
+        >
+          📝
+        </button>
+        {notesExpanded && (
+          <div className="absolute z-10 mt-1 p-2 bg-white border border-gray-300 rounded-lg shadow-lg min-w-48">
+            <textarea
+              ref={notesRef}
+              value={formData.notes}
+              onChange={(e) => handleInputChange('notes', e.target.value)}
+              onBlur={handleBlur}
+              className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+              rows={3}
+              placeholder="Notes for this set..."
+              disabled={readOnly || isSaving}
+            />
+            <div className="flex justify-end mt-2 space-x-2">
+              <button
+                onClick={() => setNotesExpanded(false)}
+                className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        )}
+      </td>
+
+      {/* Completion Status */}
+      <td className="px-2 py-3 text-center w-12">
+        {isSaving ? (
+          <div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto"></div>
+        ) : (
+          <button
+            onClick={handleToggleCompletion}
+            disabled={readOnly}
+            className={`w-6 h-6 rounded-full flex items-center justify-center mx-auto transition-all duration-200 ${
+              readOnly 
+                ? 'cursor-not-allowed opacity-50' 
+                : 'cursor-pointer hover:scale-110 transform'
+            } ${
+              isCompleted
+                ? 'bg-green-500 text-white hover:bg-green-600 shadow-md'
+                : 'border-2 border-gray-300 hover:border-green-400 hover:bg-green-50'
+            }`}
+            title={isCompleted ? 'Mark incomplete' : 'Mark complete'}
+          >
+            {isCompleted && (
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            )}
+          </button>
+        )}
+      </td>
+
+      {/* Error display */}
+      {error && (
+        <td colSpan={7} className="px-2 py-1">
+          <div className="text-xs text-red-600 bg-red-50 rounded px-2 py-1">
+            {error}
+          </div>
+        </td>
+      )}
+    </>
+  );
+};
+
+export default SortableInlineSetRow;


### PR DESCRIPTION
### Inline Editing Implementation (Frontend)

Replaces modal-based set tracking with seamless inline editing for mobile-first workout experience.

**Problem Solved**

Modal overhead: Reduced 3+ clicks per set to 1-2 interactions
Context switching: Eliminated loss of workout overview during set input
Mobile friction: Optimized for 99% mobile usage during workouts

**Key Features**

Inline editing: Click any cell to edit weight/reps/RPE directly in table
Persistent expansion: Exercises remember expanded state across page reloads
Drag-and-drop reordering: Hamburger handles (≡) for intuitive set reordering
Toggleable completion: Click checkmarks to mark sets complete/incomplete
Single expansion level: Simplified from confusing double-expansion

**Technical Implementation**

New Components: SortableInlineSetRow.tsx with integrated drag-and-drop
State Management: localStorage-based expansion + forceExpanded prop
Modal Elimination: Replaced ExerciseList modal system with inline rendering
Mobile Optimization: Responsive column widths and touch-friendly targets

User Experience: Streamlined workout logging workflow
Performance: Eliminated modal rendering overhead
Accessibility: Better semantic structure with table layout
Maintenance: Consolidated component architecture