### PR TITLE
feat: Add decimal to keyboard to allow for precise numbers

### DIFF
--- a/flow-frontend/src/components/SortableInlineSetRow.tsx
+++ b/flow-frontend/src/components/SortableInlineSetRow.tsx
@@ -274,8 +274,8 @@ const InlineSetRowContent: React.FC<SortableInlineSetRowProps> = ({
       <td className="px-1 py-2 w-16">
         <input
           type="number"
-          inputMode="numeric"
-          pattern="[0-9]*"
+          inputMode="decimal"
+          step="0.5"
           value={displayData.weight}
           onChange={(e) => handleWeightChange(e.target.value)}
           onFocus={(e) => e.target.select()}
@@ -304,8 +304,10 @@ const InlineSetRowContent: React.FC<SortableInlineSetRowProps> = ({
       <td className="px-1 py-2 w-12">
         <input
           type="number"
-          inputMode="numeric"
-          pattern="[0-9]*"
+          inputMode="decimal"
+          step="0.5"
+          min="1"
+          max="10"
           value={displayData.rpe || ''}
           onChange={(e) => handleRpeChange(e.target.value)}
           onFocus={(e) => e.target.select()}

--- a/flow-frontend/src/components/WorkoutForm.tsx
+++ b/flow-frontend/src/components/WorkoutForm.tsx
@@ -266,8 +266,8 @@ const WorkoutForm = ({ dayId, onSave, athleteId }: WorkoutFormProps) => {
                 <label className="block text-xs text-gray-500">Weight ({displayUnit})</label>
                 <input
                   type="number"
-                  inputMode="numeric"
-                  pattern="[0-9]*"
+                  inputMode="decimal"
+                  step="0.5"
                   defaultValue={set.weight || ''}
                   onChange={(e) => {
                     const value = e.target.value;
@@ -307,8 +307,8 @@ const WorkoutForm = ({ dayId, onSave, athleteId }: WorkoutFormProps) => {
                 <label className="block text-xs text-gray-500">RPE</label>
                 <input
                   type="number"
-                  inputMode="numeric"
-                  pattern="[0-9]*"
+                  inputMode="decimal"
+                  step="0.5"
                   defaultValue={set.rpe}
                   onChange={(e) => {
                     const value = e.target.value;


### PR DESCRIPTION
- Remove pattern="[0-9]*" blocking decimal keyboard
- Add inputMode="decimal" and step="0.5" for precision
- Support powerlifting increments (102.5kg, RPE 6.5)
- Enhanced UX for mobile weight/RPE tracking