### PR TITLE
Feat/dashboard training summary cards

### DIFF
--- a/backend/app-stack.yaml
+++ b/backend/app-stack.yaml
@@ -601,8 +601,15 @@ Resources:
           Properties:
             RestApiId: !Ref FlowAPI
             Path: /analytics/block-comparison/{athlete_id}
-            Method: get     
-  
+            Method: get
+
+        DashboardSummary:
+          Type: Api
+          Properties:
+            RestApiId: !Ref FlowAPI
+            Path: /analytics/dashboard-summary/{athlete_id}
+            Method: get
+
   # Health Check Lambda function
   HealthFunction:
     Type: AWS::Serverless::Function

--- a/backend/layers/common/python/src/api/analytics_api.py
+++ b/backend/layers/common/python/src/api/analytics_api.py
@@ -433,6 +433,7 @@ def get_dashboard_summary(event, context):
     Returns SBD PR cards and weekly volume summary for the dashboard.
     """
     try:
+        # Extract path parameters and query parameters
         athlete_id = event["pathParameters"]["athlete_id"]
         query_params = event.get("queryStringParameters") or {}
         block_id = query_params.get("block_id")

--- a/backend/layers/common/python/src/api/analytics_api.py
+++ b/backend/layers/common/python/src/api/analytics_api.py
@@ -424,3 +424,45 @@ def get_all_time_1rm(event, context):
     except Exception as e:
         logger.error(f"Error getting all-time 1RM: {str(e)}")
         return create_response(500, {"error": "Internal server error"})
+
+
+@with_middleware([log_request, handle_errors])
+def get_dashboard_summary(event, context):
+    """
+    Handle GET /analytics/dashboard-summary/{athlete_id}?block_id=<block_id>
+    Returns SBD PR cards and weekly volume summary for the dashboard.
+    """
+    try:
+        athlete_id = event["pathParameters"]["athlete_id"]
+        query_params = event.get("queryStringParameters") or {}
+        block_id = query_params.get("block_id")
+
+        if not block_id:
+            return create_response(
+                400, {"error": "block_id query parameter is required"}
+            )
+
+        user_id = event["requestContext"]["authorizer"]["claims"]["sub"]
+        if not validate_athlete_access(user_id, athlete_id):
+            return create_response(
+                403, {"error": "Unauthorized access to athlete data"}
+            )
+
+        block = block_service.get_block(block_id)
+        if not block:
+            return create_response(404, {"error": "Block not found"})
+        if block.athlete_id != athlete_id:
+            return create_response(
+                403, {"error": "Block does not belong to specified athlete"}
+            )
+
+        result = analytics_service.get_dashboard_summary(athlete_id, block_id)
+
+        if "error" in result:
+            return create_response(400, result)
+
+        return create_response(200, result)
+
+    except Exception as e:
+        logger.error(f"Error getting dashboard summary: {str(e)}", exc_info=True)
+        return create_response(500, {"error": "Internal server error"})

--- a/backend/layers/common/python/src/services/analytics_service.py
+++ b/backend/layers/common/python/src/services/analytics_service.py
@@ -466,10 +466,14 @@ class AnalyticsService:
             weeks = self.week_repository.get_weeks_by_block(active_block_id)
             week_ids = [w["week_id"] for w in weeks if w.get("week_id")]
             all_days = self.day_repository.batch_get_days_by_week_ids(week_ids)
-            day_ids = [d["day_id"] for d in all_days if d.get("day_id")]
-            all_exercises = self.exercise_repository.batch_get_exercises_by_day_ids(
-                day_ids
-            )
+            block_end = active_block.get("end_date", "9999-99-99")
+            all_exercises = [
+                e
+                for e in self.exercise_repository.get_exercises_with_workout_context(
+                    athlete_id, start_date=active_block.get("start_date")
+                )
+                if e.get("workout_date", "") <= block_end
+            ]
 
             # --- PR cards ---
             current_prs = self._extract_sbd_bests(all_exercises)
@@ -477,7 +481,9 @@ class AnalyticsService:
             all_blocks = self.block_repository.get_blocks_by_athlete(athlete_id)
             prev_block = self._find_previous_block(all_blocks, active_block)
             previous_prs = (
-                self._get_block_sbd_bests(prev_block["block_id"]) if prev_block else {}
+                self._get_block_sbd_bests(prev_block["block_id"], athlete_id)
+                if prev_block
+                else {}
             )
 
             prs = {}
@@ -517,14 +523,21 @@ class AnalyticsService:
                     bests[canonical] = max_w
         return bests
 
-    def _get_block_sbd_bests(self, block_id: str) -> Dict[str, float]:
+    def _get_block_sbd_bests(self, block_id: str, athlete_id: str) -> Dict[str, float]:
         """Fetch exercises for a block and return SBD bests (used for previous block)."""
         try:
-            weeks = self.week_repository.get_weeks_by_block(block_id)
-            week_ids = [w["week_id"] for w in weeks if w.get("week_id")]
-            all_days = self.day_repository.batch_get_days_by_week_ids(week_ids)
-            day_ids = [d["day_id"] for d in all_days if d.get("day_id")]
-            exercises = self.exercise_repository.batch_get_exercises_by_day_ids(day_ids)
+            block = self.block_repository.get_block(block_id)
+            if not block:
+                return {}
+            start_date = block.get("start_date")
+            end_date = block.get("end_date", "9999-99-99")
+            exercises = [
+                e
+                for e in self.exercise_repository.get_exercises_with_workout_context(
+                    athlete_id, start_date=start_date
+                )
+                if e.get("workout_date", "") <= end_date
+            ]
             return self._extract_sbd_bests(exercises)
         except Exception as e:
             print(f"Error fetching previous block SBD bests for {block_id}: {e}")
@@ -559,7 +572,6 @@ class AnalyticsService:
         """
         today = dt.date.today().isoformat()
         week_lookup = {w["week_id"]: w for w in weeks if w.get("week_id")}
-        day_lookup = {d["day_id"]: d for d in all_days if d.get("day_id")}
 
         # week_id -> list of day dates
         week_dates: Dict[str, List[str]] = {}
@@ -599,14 +611,19 @@ class AnalyticsService:
             None,
         )
 
+        # Build date -> week_id lookup for fast matching
+        date_to_week: Dict[str, str] = {}
+        for wid, dates in week_dates.items():
+            for date in dates:
+                date_to_week[date] = wid
+
         # Calculate volume per week using completed exercises
         week_volumes: Dict[str, float] = {}
         for exercise in all_exercises:
-            did = exercise.get("day_id")
-            if not did:
+            workout_date = exercise.get("workout_date")
+            if not workout_date:
                 continue
-            day_data = day_lookup.get(did, {})
-            wid = day_data.get("week_id")
+            wid = date_to_week.get(workout_date)
             if wid and self._is_exercise_analytics_complete(exercise):
                 vol = self._calculate_exercise_volume(exercise)
                 week_volumes[wid] = week_volumes.get(wid, 0.0) + vol

--- a/backend/layers/common/python/src/services/analytics_service.py
+++ b/backend/layers/common/python/src/services/analytics_service.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any, Union
+from typing import List, Dict, Any, Union, Optional
 from src.repositories.exercise_repository import ExerciseRepository
 from src.repositories.block_repository import BlockRepository
 from src.repositories.week_repository import WeekRepository
@@ -7,6 +7,8 @@ import datetime as dt
 
 
 class AnalyticsService:
+    _SBD_EXERCISES = ["Squat", "Bench Press", "Deadlift"]
+
     def __init__(self):
         self.exercise_repository: ExerciseRepository = ExerciseRepository()
         self.block_repository: BlockRepository = BlockRepository()
@@ -440,6 +442,185 @@ class AnalyticsService:
         except Exception as e:
             print(f"Error in calculate_block_volume: {e}")
             return {"error": f"Failed to calculate block volume: {str(e)}"}
+
+    def get_dashboard_summary(
+        self, athlete_id: str, active_block_id: str
+    ) -> Dict[str, Any]:
+        """
+        Return SBD PR cards and weekly volume summary for the dashboard.
+        Fetches active block exercises once; reuses data for both PRs and volume.
+
+        :param athlete_id: The athlete's user ID
+        :param active_block_id: The ID of the active training block
+        :return: Dict with 'prs' and 'weekly_volume' keys
+        """
+        if not athlete_id or not active_block_id:
+            return {"error": "athlete_id and block_id are required"}
+
+        try:
+            active_block = self.block_repository.get_block(active_block_id)
+            if not active_block:
+                return {"error": "Block not found"}
+
+            # Fetch active block data once — reused for both PRs and weekly volume
+            weeks = self.week_repository.get_weeks_by_block(active_block_id)
+            week_ids = [w["week_id"] for w in weeks if w.get("week_id")]
+            all_days = self.day_repository.batch_get_days_by_week_ids(week_ids)
+            day_ids = [d["day_id"] for d in all_days if d.get("day_id")]
+            all_exercises = self.exercise_repository.batch_get_exercises_by_day_ids(
+                day_ids
+            )
+
+            # --- PR cards ---
+            current_prs = self._extract_sbd_bests(all_exercises)
+
+            all_blocks = self.block_repository.get_blocks_by_athlete(athlete_id)
+            prev_block = self._find_previous_block(all_blocks, active_block)
+            previous_prs = (
+                self._get_block_sbd_bests(prev_block["block_id"]) if prev_block else {}
+            )
+
+            prs = {}
+            for lift in self._SBD_EXERCISES:
+                current_best = current_prs.get(lift, 0.0)
+                previous_best = previous_prs.get(lift, 0.0)
+                prs[lift] = {
+                    "current_block_best": current_best,
+                    "previous_block_best": previous_best,
+                    "delta": (
+                        round(current_best - previous_best, 2)
+                        if previous_best > 0
+                        else None
+                    ),
+                }
+
+            # --- Weekly volume ---
+            weekly_volume = self._compute_weekly_volume(weeks, all_days, all_exercises)
+
+            return {"prs": prs, "weekly_volume": weekly_volume}
+
+        except Exception as e:
+            print(f"Error in get_dashboard_summary: {e}")
+            return {"error": "Failed to get dashboard summary"}
+
+    def _extract_sbd_bests(self, exercises: List[Dict[str, Any]]) -> Dict[str, float]:
+        """Return best top-set weight for each SBD lift from a list of exercises."""
+        # Case-insensitive lookup: lowercase key -> canonical name
+        lower_to_canonical = {lift.lower(): lift for lift in self._SBD_EXERCISES}
+        bests: Dict[str, float] = {lift: 0.0 for lift in self._SBD_EXERCISES}
+        for exercise in exercises:
+            ex_type = exercise.get("exercise_type", "")
+            canonical = lower_to_canonical.get(ex_type.lower())
+            if canonical:
+                max_w = self._get_max_weight_from_exercise(exercise)
+                if max_w > bests[canonical]:
+                    bests[canonical] = max_w
+        return bests
+
+    def _get_block_sbd_bests(self, block_id: str) -> Dict[str, float]:
+        """Fetch exercises for a block and return SBD bests (used for previous block)."""
+        try:
+            weeks = self.week_repository.get_weeks_by_block(block_id)
+            week_ids = [w["week_id"] for w in weeks if w.get("week_id")]
+            all_days = self.day_repository.batch_get_days_by_week_ids(week_ids)
+            day_ids = [d["day_id"] for d in all_days if d.get("day_id")]
+            exercises = self.exercise_repository.batch_get_exercises_by_day_ids(day_ids)
+            return self._extract_sbd_bests(exercises)
+        except Exception as e:
+            print(f"Error fetching previous block SBD bests for {block_id}: {e}")
+            return {}
+
+    def _find_previous_block(
+        self, all_blocks: List[Dict[str, Any]], active_block: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Return the most recent block whose end_date is before active_block start_date."""
+        active_start = active_block.get("start_date", "")
+        candidates = [
+            b
+            for b in all_blocks
+            if b.get("block_id") != active_block.get("block_id")
+            and b.get("end_date", "") < active_start
+        ]
+        if not candidates:
+            return None
+        return max(
+            candidates, key=lambda b: (b.get("end_date", ""), b.get("block_id", ""))
+        )
+
+    def _compute_weekly_volume(
+        self,
+        weeks: List[Dict[str, Any]],
+        all_days: List[Dict[str, Any]],
+        all_exercises: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """
+        Identify current week (contains today, or latest week if today is past block end)
+        and its previous week. Return their volumes.
+        """
+        today = dt.date.today().isoformat()
+        week_lookup = {w["week_id"]: w for w in weeks if w.get("week_id")}
+        day_lookup = {d["day_id"]: d for d in all_days if d.get("day_id")}
+
+        # week_id -> list of day dates
+        week_dates: Dict[str, List[str]] = {}
+        for day in all_days:
+            wid = day.get("week_id")
+            date = day.get("date")
+            if wid and date:
+                week_dates.setdefault(wid, []).append(date)
+
+        sorted_weeks = sorted(weeks, key=lambda w: w.get("week_number", 0))
+
+        # Find current week: day range contains today
+        current_week_id = None
+        for week in sorted_weeks:
+            wid = week.get("week_id")
+            if not wid or wid not in week_dates:
+                continue
+            dates = week_dates[wid]
+            if min(dates) <= today <= max(dates):
+                current_week_id = wid
+                break
+
+        # Fallback: today is past block end — use last week
+        if not current_week_id and sorted_weeks:
+            current_week_id = sorted_weeks[-1].get("week_id")
+
+        if not current_week_id:
+            return {}
+
+        current_week_number = week_lookup[current_week_id].get("week_number", 0)
+        prev_week_id = next(
+            (
+                w["week_id"]
+                for w in sorted_weeks
+                if w.get("week_number") == current_week_number - 1
+            ),
+            None,
+        )
+
+        # Calculate volume per week using completed exercises
+        week_volumes: Dict[str, float] = {}
+        for exercise in all_exercises:
+            did = exercise.get("day_id")
+            if not did:
+                continue
+            day_data = day_lookup.get(did, {})
+            wid = day_data.get("week_id")
+            if wid and self._is_exercise_analytics_complete(exercise):
+                vol = self._calculate_exercise_volume(exercise)
+                week_volumes[wid] = week_volumes.get(wid, 0.0) + vol
+
+        result: Dict[str, Any] = {
+            "current_week_number": current_week_number,
+            "current_week_volume": round(week_volumes.get(current_week_id, 0.0), 2),
+        }
+        if prev_week_id:
+            result["previous_week_number"] = current_week_number - 1
+            result["previous_week_volume"] = round(
+                week_volumes.get(prev_week_id, 0.0), 2
+            )
+        return result
 
     def compare_blocks(self, block_id1: str, block_id2: str) -> Dict[str, Any]:
         """

--- a/backend/src/api/analytics_api.py
+++ b/backend/src/api/analytics_api.py
@@ -433,6 +433,7 @@ def get_dashboard_summary(event, context):
     Returns SBD PR cards and weekly volume summary for the dashboard.
     """
     try:
+        # Extract path parameters and query parameters
         athlete_id = event["pathParameters"]["athlete_id"]
         query_params = event.get("queryStringParameters") or {}
         block_id = query_params.get("block_id")

--- a/backend/src/api/analytics_api.py
+++ b/backend/src/api/analytics_api.py
@@ -424,3 +424,45 @@ def get_all_time_1rm(event, context):
     except Exception as e:
         logger.error(f"Error getting all-time 1RM: {str(e)}")
         return create_response(500, {"error": "Internal server error"})
+
+
+@with_middleware([log_request, handle_errors])
+def get_dashboard_summary(event, context):
+    """
+    Handle GET /analytics/dashboard-summary/{athlete_id}?block_id=<block_id>
+    Returns SBD PR cards and weekly volume summary for the dashboard.
+    """
+    try:
+        athlete_id = event["pathParameters"]["athlete_id"]
+        query_params = event.get("queryStringParameters") or {}
+        block_id = query_params.get("block_id")
+
+        if not block_id:
+            return create_response(
+                400, {"error": "block_id query parameter is required"}
+            )
+
+        user_id = event["requestContext"]["authorizer"]["claims"]["sub"]
+        if not validate_athlete_access(user_id, athlete_id):
+            return create_response(
+                403, {"error": "Unauthorized access to athlete data"}
+            )
+
+        block = block_service.get_block(block_id)
+        if not block:
+            return create_response(404, {"error": "Block not found"})
+        if block.athlete_id != athlete_id:
+            return create_response(
+                403, {"error": "Block does not belong to specified athlete"}
+            )
+
+        result = analytics_service.get_dashboard_summary(athlete_id, block_id)
+
+        if "error" in result:
+            return create_response(400, result)
+
+        return create_response(200, result)
+
+    except Exception as e:
+        logger.error(f"Error getting dashboard summary: {str(e)}", exc_info=True)
+        return create_response(500, {"error": "Internal server error"})

--- a/backend/src/lambdas/analytics_lambda/analytics_lambda.py
+++ b/backend/src/lambdas/analytics_lambda/analytics_lambda.py
@@ -14,6 +14,7 @@ ROUTE_MAP = {
     "GET /analytics/block-analysis/{athlete_id}/{block_id}": analytics_api.get_block_analysis,
     "GET /analytics/block-comparison/{athlete_id}": analytics_api.get_block_comparison,
     "GET /analytics/1rm-alltime/{athlete_id}": analytics_api.get_all_time_1rm,
+    "GET /analytics/dashboard-summary/{athlete_id}": analytics_api.get_dashboard_summary,
 }
 
 

--- a/backend/src/services/analytics_service.py
+++ b/backend/src/services/analytics_service.py
@@ -466,10 +466,14 @@ class AnalyticsService:
             weeks = self.week_repository.get_weeks_by_block(active_block_id)
             week_ids = [w["week_id"] for w in weeks if w.get("week_id")]
             all_days = self.day_repository.batch_get_days_by_week_ids(week_ids)
-            day_ids = [d["day_id"] for d in all_days if d.get("day_id")]
-            all_exercises = self.exercise_repository.batch_get_exercises_by_day_ids(
-                day_ids
-            )
+            block_end = active_block.get("end_date", "9999-99-99")
+            all_exercises = [
+                e
+                for e in self.exercise_repository.get_exercises_with_workout_context(
+                    athlete_id, start_date=active_block.get("start_date")
+                )
+                if e.get("workout_date", "") <= block_end
+            ]
 
             # --- PR cards ---
             current_prs = self._extract_sbd_bests(all_exercises)
@@ -477,7 +481,9 @@ class AnalyticsService:
             all_blocks = self.block_repository.get_blocks_by_athlete(athlete_id)
             prev_block = self._find_previous_block(all_blocks, active_block)
             previous_prs = (
-                self._get_block_sbd_bests(prev_block["block_id"]) if prev_block else {}
+                self._get_block_sbd_bests(prev_block["block_id"], athlete_id)
+                if prev_block
+                else {}
             )
 
             prs = {}
@@ -517,14 +523,21 @@ class AnalyticsService:
                     bests[canonical] = max_w
         return bests
 
-    def _get_block_sbd_bests(self, block_id: str) -> Dict[str, float]:
+    def _get_block_sbd_bests(self, block_id: str, athlete_id: str) -> Dict[str, float]:
         """Fetch exercises for a block and return SBD bests (used for previous block)."""
         try:
-            weeks = self.week_repository.get_weeks_by_block(block_id)
-            week_ids = [w["week_id"] for w in weeks if w.get("week_id")]
-            all_days = self.day_repository.batch_get_days_by_week_ids(week_ids)
-            day_ids = [d["day_id"] for d in all_days if d.get("day_id")]
-            exercises = self.exercise_repository.batch_get_exercises_by_day_ids(day_ids)
+            block = self.block_repository.get_block(block_id)
+            if not block:
+                return {}
+            start_date = block.get("start_date")
+            end_date = block.get("end_date", "9999-99-99")
+            exercises = [
+                e
+                for e in self.exercise_repository.get_exercises_with_workout_context(
+                    athlete_id, start_date=start_date
+                )
+                if e.get("workout_date", "") <= end_date
+            ]
             return self._extract_sbd_bests(exercises)
         except Exception as e:
             print(f"Error fetching previous block SBD bests for {block_id}: {e}")
@@ -559,7 +572,6 @@ class AnalyticsService:
         """
         today = dt.date.today().isoformat()
         week_lookup = {w["week_id"]: w for w in weeks if w.get("week_id")}
-        day_lookup = {d["day_id"]: d for d in all_days if d.get("day_id")}
 
         # week_id -> list of day dates
         week_dates: Dict[str, List[str]] = {}
@@ -599,14 +611,19 @@ class AnalyticsService:
             None,
         )
 
+        # Build date -> week_id lookup for fast matching
+        date_to_week: Dict[str, str] = {}
+        for wid, dates in week_dates.items():
+            for date in dates:
+                date_to_week[date] = wid
+
         # Calculate volume per week using completed exercises
         week_volumes: Dict[str, float] = {}
         for exercise in all_exercises:
-            did = exercise.get("day_id")
-            if not did:
+            workout_date = exercise.get("workout_date")
+            if not workout_date:
                 continue
-            day_data = day_lookup.get(did, {})
-            wid = day_data.get("week_id")
+            wid = date_to_week.get(workout_date)
             if wid and self._is_exercise_analytics_complete(exercise):
                 vol = self._calculate_exercise_volume(exercise)
                 week_volumes[wid] = week_volumes.get(wid, 0.0) + vol

--- a/backend/src/services/analytics_service.py
+++ b/backend/src/services/analytics_service.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any, Union
+from typing import List, Dict, Any, Union, Optional
 from src.repositories.exercise_repository import ExerciseRepository
 from src.repositories.block_repository import BlockRepository
 from src.repositories.week_repository import WeekRepository
@@ -7,6 +7,8 @@ import datetime as dt
 
 
 class AnalyticsService:
+    _SBD_EXERCISES = ["Squat", "Bench Press", "Deadlift"]
+
     def __init__(self):
         self.exercise_repository: ExerciseRepository = ExerciseRepository()
         self.block_repository: BlockRepository = BlockRepository()
@@ -440,6 +442,185 @@ class AnalyticsService:
         except Exception as e:
             print(f"Error in calculate_block_volume: {e}")
             return {"error": f"Failed to calculate block volume: {str(e)}"}
+
+    def get_dashboard_summary(
+        self, athlete_id: str, active_block_id: str
+    ) -> Dict[str, Any]:
+        """
+        Return SBD PR cards and weekly volume summary for the dashboard.
+        Fetches active block exercises once; reuses data for both PRs and volume.
+
+        :param athlete_id: The athlete's user ID
+        :param active_block_id: The ID of the active training block
+        :return: Dict with 'prs' and 'weekly_volume' keys
+        """
+        if not athlete_id or not active_block_id:
+            return {"error": "athlete_id and block_id are required"}
+
+        try:
+            active_block = self.block_repository.get_block(active_block_id)
+            if not active_block:
+                return {"error": "Block not found"}
+
+            # Fetch active block data once — reused for both PRs and weekly volume
+            weeks = self.week_repository.get_weeks_by_block(active_block_id)
+            week_ids = [w["week_id"] for w in weeks if w.get("week_id")]
+            all_days = self.day_repository.batch_get_days_by_week_ids(week_ids)
+            day_ids = [d["day_id"] for d in all_days if d.get("day_id")]
+            all_exercises = self.exercise_repository.batch_get_exercises_by_day_ids(
+                day_ids
+            )
+
+            # --- PR cards ---
+            current_prs = self._extract_sbd_bests(all_exercises)
+
+            all_blocks = self.block_repository.get_blocks_by_athlete(athlete_id)
+            prev_block = self._find_previous_block(all_blocks, active_block)
+            previous_prs = (
+                self._get_block_sbd_bests(prev_block["block_id"]) if prev_block else {}
+            )
+
+            prs = {}
+            for lift in self._SBD_EXERCISES:
+                current_best = current_prs.get(lift, 0.0)
+                previous_best = previous_prs.get(lift, 0.0)
+                prs[lift] = {
+                    "current_block_best": current_best,
+                    "previous_block_best": previous_best,
+                    "delta": (
+                        round(current_best - previous_best, 2)
+                        if previous_best > 0
+                        else None
+                    ),
+                }
+
+            # --- Weekly volume ---
+            weekly_volume = self._compute_weekly_volume(weeks, all_days, all_exercises)
+
+            return {"prs": prs, "weekly_volume": weekly_volume}
+
+        except Exception as e:
+            print(f"Error in get_dashboard_summary: {e}")
+            return {"error": "Failed to get dashboard summary"}
+
+    def _extract_sbd_bests(self, exercises: List[Dict[str, Any]]) -> Dict[str, float]:
+        """Return best top-set weight for each SBD lift from a list of exercises."""
+        # Case-insensitive lookup: lowercase key -> canonical name
+        lower_to_canonical = {lift.lower(): lift for lift in self._SBD_EXERCISES}
+        bests: Dict[str, float] = {lift: 0.0 for lift in self._SBD_EXERCISES}
+        for exercise in exercises:
+            ex_type = exercise.get("exercise_type", "")
+            canonical = lower_to_canonical.get(ex_type.lower())
+            if canonical:
+                max_w = self._get_max_weight_from_exercise(exercise)
+                if max_w > bests[canonical]:
+                    bests[canonical] = max_w
+        return bests
+
+    def _get_block_sbd_bests(self, block_id: str) -> Dict[str, float]:
+        """Fetch exercises for a block and return SBD bests (used for previous block)."""
+        try:
+            weeks = self.week_repository.get_weeks_by_block(block_id)
+            week_ids = [w["week_id"] for w in weeks if w.get("week_id")]
+            all_days = self.day_repository.batch_get_days_by_week_ids(week_ids)
+            day_ids = [d["day_id"] for d in all_days if d.get("day_id")]
+            exercises = self.exercise_repository.batch_get_exercises_by_day_ids(day_ids)
+            return self._extract_sbd_bests(exercises)
+        except Exception as e:
+            print(f"Error fetching previous block SBD bests for {block_id}: {e}")
+            return {}
+
+    def _find_previous_block(
+        self, all_blocks: List[Dict[str, Any]], active_block: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Return the most recent block whose end_date is before active_block start_date."""
+        active_start = active_block.get("start_date", "")
+        candidates = [
+            b
+            for b in all_blocks
+            if b.get("block_id") != active_block.get("block_id")
+            and b.get("end_date", "") < active_start
+        ]
+        if not candidates:
+            return None
+        return max(
+            candidates, key=lambda b: (b.get("end_date", ""), b.get("block_id", ""))
+        )
+
+    def _compute_weekly_volume(
+        self,
+        weeks: List[Dict[str, Any]],
+        all_days: List[Dict[str, Any]],
+        all_exercises: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """
+        Identify current week (contains today, or latest week if today is past block end)
+        and its previous week. Return their volumes.
+        """
+        today = dt.date.today().isoformat()
+        week_lookup = {w["week_id"]: w for w in weeks if w.get("week_id")}
+        day_lookup = {d["day_id"]: d for d in all_days if d.get("day_id")}
+
+        # week_id -> list of day dates
+        week_dates: Dict[str, List[str]] = {}
+        for day in all_days:
+            wid = day.get("week_id")
+            date = day.get("date")
+            if wid and date:
+                week_dates.setdefault(wid, []).append(date)
+
+        sorted_weeks = sorted(weeks, key=lambda w: w.get("week_number", 0))
+
+        # Find current week: day range contains today
+        current_week_id = None
+        for week in sorted_weeks:
+            wid = week.get("week_id")
+            if not wid or wid not in week_dates:
+                continue
+            dates = week_dates[wid]
+            if min(dates) <= today <= max(dates):
+                current_week_id = wid
+                break
+
+        # Fallback: today is past block end — use last week
+        if not current_week_id and sorted_weeks:
+            current_week_id = sorted_weeks[-1].get("week_id")
+
+        if not current_week_id:
+            return {}
+
+        current_week_number = week_lookup[current_week_id].get("week_number", 0)
+        prev_week_id = next(
+            (
+                w["week_id"]
+                for w in sorted_weeks
+                if w.get("week_number") == current_week_number - 1
+            ),
+            None,
+        )
+
+        # Calculate volume per week using completed exercises
+        week_volumes: Dict[str, float] = {}
+        for exercise in all_exercises:
+            did = exercise.get("day_id")
+            if not did:
+                continue
+            day_data = day_lookup.get(did, {})
+            wid = day_data.get("week_id")
+            if wid and self._is_exercise_analytics_complete(exercise):
+                vol = self._calculate_exercise_volume(exercise)
+                week_volumes[wid] = week_volumes.get(wid, 0.0) + vol
+
+        result: Dict[str, Any] = {
+            "current_week_number": current_week_number,
+            "current_week_volume": round(week_volumes.get(current_week_id, 0.0), 2),
+        }
+        if prev_week_id:
+            result["previous_week_number"] = current_week_number - 1
+            result["previous_week_volume"] = round(
+                week_volumes.get(prev_week_id, 0.0), 2
+            )
+        return result
 
     def compare_blocks(self, block_id1: str, block_id2: str) -> Dict[str, Any]:
         """

--- a/backend/tests/api/test_analytics_api.py
+++ b/backend/tests/api/test_analytics_api.py
@@ -33,9 +33,13 @@ class TestAnalyticsAPI(unittest.TestCase):
         self.user_service_patcher = patch(
             "src.api.analytics_api.user_service", self.mock_user_service
         )
+        self.block_service_patcher = patch(
+            "src.api.analytics_api.block_service", self.mock_block_service
+        )
 
         self.analytics_service_patcher.start()
         self.user_service_patcher.start()
+        self.block_service_patcher.start()
 
         # Mock event structure
         self.base_event = {
@@ -51,6 +55,7 @@ class TestAnalyticsAPI(unittest.TestCase):
         self.uuid_patcher.stop()
         self.analytics_service_patcher.stop()
         self.user_service_patcher.stop()
+        self.block_service_patcher.stop()
 
     def test_validate_date_format_valid_dates(self):
         """Test validate_date_format with valid date strings"""
@@ -1379,6 +1384,77 @@ class TestAnalyticsAPI(unittest.TestCase):
 
         # Should not call analytics service
         self.mock_analytics_service.get_all_time_max_weight.assert_not_called()
+
+    def test_get_dashboard_summary_success(self):
+        """Returns 200 with summary data when block belongs to athlete"""
+        from src.api.analytics_api import get_dashboard_summary
+
+        self.mock_analytics_service.get_dashboard_summary.return_value = {
+            "prs": {
+                "Squat": {
+                    "current_block_best": 150.0,
+                    "previous_block_best": 140.0,
+                    "delta": 10.0,
+                },
+                "Bench Press": {
+                    "current_block_best": 100.0,
+                    "previous_block_best": 0.0,
+                    "delta": None,
+                },
+                "Deadlift": {
+                    "current_block_best": 0.0,
+                    "previous_block_best": 0.0,
+                    "delta": None,
+                },
+            },
+            "weekly_volume": {
+                "current_week_number": 2,
+                "current_week_volume": 5000.0,
+                "previous_week_number": 1,
+                "previous_week_volume": 4500.0,
+            },
+        }
+
+        mock_block = MagicMock()
+        mock_block.athlete_id = "test-athlete-id"
+        self.mock_block_service.get_block.return_value = mock_block
+
+        event = {
+            **self.base_event,
+            "queryStringParameters": {"block_id": "test-block-id"},
+            "requestContext": {"authorizer": {"claims": {"sub": "test-athlete-id"}}},
+        }
+        with patch("src.api.analytics_api.validate_athlete_access", return_value=True):
+            response = get_dashboard_summary(event, self.context)
+
+        self.assertEqual(response["statusCode"], 200)
+        body = json.loads(response["body"])
+        self.assertIn("prs", body)
+        self.assertIn("weekly_volume", body)
+        self.mock_analytics_service.get_dashboard_summary.assert_called_once_with(
+            "test-athlete-id", "test-block-id"
+        )
+
+    def test_get_dashboard_summary_missing_block_id(self):
+        """Returns 400 when block_id query param is missing"""
+        from src.api.analytics_api import get_dashboard_summary
+
+        event = {**self.base_event, "queryStringParameters": {}}
+        with patch("src.api.analytics_api.validate_athlete_access", return_value=True):
+            response = get_dashboard_summary(event, self.context)
+        self.assertEqual(response["statusCode"], 400)
+
+    def test_get_dashboard_summary_unauthorized(self):
+        """Returns 403 when user cannot access athlete data"""
+        from src.api.analytics_api import get_dashboard_summary
+
+        event = {
+            **self.base_event,
+            "queryStringParameters": {"block_id": "test-block-id"},
+        }
+        with patch("src.api.analytics_api.validate_athlete_access", return_value=False):
+            response = get_dashboard_summary(event, self.context)
+        self.assertEqual(response["statusCode"], 403)
 
 
 if __name__ == "__main__":

--- a/backend/tests/api/test_analytics_api.py
+++ b/backend/tests/api/test_analytics_api.py
@@ -1456,6 +1456,74 @@ class TestAnalyticsAPI(unittest.TestCase):
             response = get_dashboard_summary(event, self.context)
         self.assertEqual(response["statusCode"], 403)
 
+    def test_get_dashboard_summary_block_not_found(self):
+        """Returns 404 when block does not exist"""
+        from src.api.analytics_api import get_dashboard_summary
+
+        self.mock_block_service.get_block.return_value = None
+        event = {
+            **self.base_event,
+            "queryStringParameters": {"block_id": "nonexistent-block"},
+            "requestContext": {"authorizer": {"claims": {"sub": "test-athlete-id"}}},
+        }
+        with patch("src.api.analytics_api.validate_athlete_access", return_value=True):
+            response = get_dashboard_summary(event, self.context)
+        self.assertEqual(response["statusCode"], 404)
+
+    def test_get_dashboard_summary_block_wrong_athlete(self):
+        """Returns 403 when block belongs to a different athlete"""
+        from src.api.analytics_api import get_dashboard_summary
+
+        mock_block = MagicMock()
+        mock_block.athlete_id = "different-athlete-id"
+        self.mock_block_service.get_block.return_value = mock_block
+        event = {
+            **self.base_event,
+            "queryStringParameters": {"block_id": "test-block-id"},
+            "requestContext": {"authorizer": {"claims": {"sub": "test-athlete-id"}}},
+        }
+        with patch("src.api.analytics_api.validate_athlete_access", return_value=True):
+            response = get_dashboard_summary(event, self.context)
+        self.assertEqual(response["statusCode"], 403)
+
+    def test_get_dashboard_summary_service_returns_error(self):
+        """Returns 400 when analytics service returns an error dict"""
+        from src.api.analytics_api import get_dashboard_summary
+
+        self.mock_analytics_service.get_dashboard_summary.return_value = {
+            "error": "Block not found"
+        }
+        mock_block = MagicMock()
+        mock_block.athlete_id = "test-athlete-id"
+        self.mock_block_service.get_block.return_value = mock_block
+        event = {
+            **self.base_event,
+            "queryStringParameters": {"block_id": "test-block-id"},
+            "requestContext": {"authorizer": {"claims": {"sub": "test-athlete-id"}}},
+        }
+        with patch("src.api.analytics_api.validate_athlete_access", return_value=True):
+            response = get_dashboard_summary(event, self.context)
+        self.assertEqual(response["statusCode"], 400)
+
+    def test_get_dashboard_summary_service_exception(self):
+        """Returns 500 when analytics service raises an exception"""
+        from src.api.analytics_api import get_dashboard_summary
+
+        self.mock_analytics_service.get_dashboard_summary.side_effect = Exception(
+            "Unexpected error"
+        )
+        mock_block = MagicMock()
+        mock_block.athlete_id = "test-athlete-id"
+        self.mock_block_service.get_block.return_value = mock_block
+        event = {
+            **self.base_event,
+            "queryStringParameters": {"block_id": "test-block-id"},
+            "requestContext": {"authorizer": {"claims": {"sub": "test-athlete-id"}}},
+        }
+        with patch("src.api.analytics_api.validate_athlete_access", return_value=True):
+            response = get_dashboard_summary(event, self.context)
+        self.assertEqual(response["statusCode"], 500)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/lambdas/test_analytics_lambda.py
+++ b/backend/tests/lambdas/test_analytics_lambda.py
@@ -375,6 +375,7 @@ class TestAnalyticsLambda(BaseTest):
             "GET /analytics/block-analysis/{athlete_id}/{block_id}",
             "GET /analytics/block-comparison/{athlete_id}",
             "GET /analytics/1rm-alltime/{athlete_id}",
+            "GET /analytics/dashboard-summary/{athlete_id}",
         ]
 
         # Verify all expected routes are in ROUTE_MAP

--- a/backend/tests/services/test_analytics_service.py
+++ b/backend/tests/services/test_analytics_service.py
@@ -1669,7 +1669,9 @@ class TestAnalyticsService(unittest.TestCase):
             "start_date": "2025-10-01",
             "end_date": "2026-01-14",
         }
-        self.block_repository_mock.get_block.return_value = active_block
+        self.block_repository_mock.get_block.side_effect = (
+            lambda bid: active_block if bid == "active-block" else prev_block
+        )
         self.block_repository_mock.get_blocks_by_athlete.return_value = [
             active_block,
             prev_block,
@@ -1679,29 +1681,23 @@ class TestAnalyticsService(unittest.TestCase):
             {"week_id": "w1", "week_number": 1},
             {"week_id": "w2", "week_number": 2},
         ]
-        prev_weeks = [{"week_id": "pw1", "week_number": 1}]
-        self.week_repository_mock.get_weeks_by_block.side_effect = (
-            lambda bid: active_weeks if bid == "active-block" else prev_weeks
-        )
+        self.week_repository_mock.get_weeks_by_block.return_value = active_weeks
 
         active_days = [
             {"day_id": "d1", "week_id": "w1", "date": "2026-01-20"},
             {"day_id": "d2", "week_id": "w2", "date": today},
         ]
-        prev_days = [{"day_id": "pd1", "week_id": "pw1", "date": "2025-10-10"}]
-        self.day_repository_mock.batch_get_days_by_week_ids.side_effect = (
-            lambda ids: active_days if "w1" in ids else prev_days
-        )
+        self.day_repository_mock.batch_get_days_by_week_ids.return_value = active_days
 
         active_exercises = [
             {
-                "day_id": "d1",
+                "workout_date": "2026-01-20",
                 "exercise_type": "Squat",
                 "status": "completed",
                 "sets_data": [{"completed": True, "weight": 150, "reps": 5}],
             },
             {
-                "day_id": "d2",
+                "workout_date": today,
                 "exercise_type": "Bench Press",
                 "status": "completed",
                 "sets_data": [{"completed": True, "weight": 100, "reps": 3}],
@@ -1709,14 +1705,22 @@ class TestAnalyticsService(unittest.TestCase):
         ]
         prev_exercises = [
             {
-                "day_id": "pd1",
+                "workout_date": "2025-10-10",
                 "exercise_type": "Squat",
                 "status": "completed",
                 "sets_data": [{"completed": True, "weight": 140, "reps": 5}],
             },
         ]
-        self.exercise_repository_mock.batch_get_exercises_by_day_ids.side_effect = (
-            lambda ids: active_exercises if "d1" in ids else prev_exercises
+
+        def mock_get_exercises(athlete_id, start_date=None):
+            if start_date == "2026-01-15":
+                return active_exercises
+            elif start_date == "2025-10-01":
+                return prev_exercises
+            return []
+
+        self.exercise_repository_mock.get_exercises_with_workout_context.side_effect = (
+            mock_get_exercises
         )
 
         result = self.analytics_service.get_dashboard_summary(
@@ -1753,7 +1757,9 @@ class TestAnalyticsService(unittest.TestCase):
         self.day_repository_mock.batch_get_days_by_week_ids.return_value = [
             {"day_id": "d1", "week_id": "w1", "date": today}
         ]
-        self.exercise_repository_mock.batch_get_exercises_by_day_ids.return_value = []
+        self.exercise_repository_mock.get_exercises_with_workout_context.return_value = (
+            []
+        )
 
         result = self.analytics_service.get_dashboard_summary("athlete-1", "only-block")
 
@@ -1771,10 +1777,17 @@ class TestAnalyticsService(unittest.TestCase):
 
     def test_get_block_sbd_bests_repository_failure_returns_empty(self):
         """If previous block repository calls fail, _get_block_sbd_bests returns {} gracefully"""
-        self.week_repository_mock.get_weeks_by_block.side_effect = Exception(
-            "DynamoDB unavailable"
+        self.block_repository_mock.get_block.return_value = {
+            "block_id": "some-block-id",
+            "start_date": "2025-01-01",
+            "end_date": "2025-03-01",
+        }
+        self.exercise_repository_mock.get_exercises_with_workout_context.side_effect = (
+            Exception("DynamoDB unavailable")
         )
-        result = self.analytics_service._get_block_sbd_bests("some-block-id")
+        result = self.analytics_service._get_block_sbd_bests(
+            "some-block-id", "athlete-1"
+        )
         self.assertEqual(result, {})
 
 

--- a/backend/tests/services/test_analytics_service.py
+++ b/backend/tests/services/test_analytics_service.py
@@ -1651,6 +1651,132 @@ class TestAnalyticsService(unittest.TestCase):
         # Should return 140 (highest deadlift), ignoring 200 (squat) and 150 (bench press)
         self.assertEqual(max_weight, 140.0)
 
+    def test_get_dashboard_summary_success(self):
+        """Happy path: active block + previous block → PRs with deltas + weekly volume"""
+        import datetime as dt
+
+        today = dt.date.today().isoformat()
+
+        active_block = {
+            "block_id": "active-block",
+            "athlete_id": "athlete-1",
+            "start_date": "2026-01-15",
+            "end_date": "2026-03-15",
+        }
+        prev_block = {
+            "block_id": "prev-block",
+            "athlete_id": "athlete-1",
+            "start_date": "2025-10-01",
+            "end_date": "2026-01-14",
+        }
+        self.block_repository_mock.get_block.return_value = active_block
+        self.block_repository_mock.get_blocks_by_athlete.return_value = [
+            active_block,
+            prev_block,
+        ]
+
+        active_weeks = [
+            {"week_id": "w1", "week_number": 1},
+            {"week_id": "w2", "week_number": 2},
+        ]
+        prev_weeks = [{"week_id": "pw1", "week_number": 1}]
+        self.week_repository_mock.get_weeks_by_block.side_effect = (
+            lambda bid: active_weeks if bid == "active-block" else prev_weeks
+        )
+
+        active_days = [
+            {"day_id": "d1", "week_id": "w1", "date": "2026-01-20"},
+            {"day_id": "d2", "week_id": "w2", "date": today},
+        ]
+        prev_days = [{"day_id": "pd1", "week_id": "pw1", "date": "2025-10-10"}]
+        self.day_repository_mock.batch_get_days_by_week_ids.side_effect = (
+            lambda ids: active_days if "w1" in ids else prev_days
+        )
+
+        active_exercises = [
+            {
+                "day_id": "d1",
+                "exercise_type": "Squat",
+                "status": "completed",
+                "sets_data": [{"completed": True, "weight": 150, "reps": 5}],
+            },
+            {
+                "day_id": "d2",
+                "exercise_type": "Bench Press",
+                "status": "completed",
+                "sets_data": [{"completed": True, "weight": 100, "reps": 3}],
+            },
+        ]
+        prev_exercises = [
+            {
+                "day_id": "pd1",
+                "exercise_type": "Squat",
+                "status": "completed",
+                "sets_data": [{"completed": True, "weight": 140, "reps": 5}],
+            },
+        ]
+        self.exercise_repository_mock.batch_get_exercises_by_day_ids.side_effect = (
+            lambda ids: active_exercises if "d1" in ids else prev_exercises
+        )
+
+        result = self.analytics_service.get_dashboard_summary(
+            "athlete-1", "active-block"
+        )
+
+        self.assertNotIn("error", result)
+        self.assertEqual(result["prs"]["Squat"]["current_block_best"], 150.0)
+        self.assertEqual(result["prs"]["Squat"]["previous_block_best"], 140.0)
+        self.assertEqual(result["prs"]["Squat"]["delta"], 10.0)
+        self.assertEqual(result["prs"]["Bench Press"]["current_block_best"], 100.0)
+        self.assertIsNone(result["prs"]["Bench Press"]["delta"])  # no prev bench
+        self.assertEqual(result["prs"]["Deadlift"]["current_block_best"], 0.0)
+        self.assertEqual(result["weekly_volume"]["current_week_number"], 2)
+        self.assertIn("current_week_volume", result["weekly_volume"])
+
+    def test_get_dashboard_summary_no_previous_block(self):
+        """When athlete has only one block, all deltas are None"""
+        import datetime as dt
+
+        today = dt.date.today().isoformat()
+
+        active_block = {
+            "block_id": "only-block",
+            "athlete_id": "athlete-1",
+            "start_date": "2026-01-01",
+            "end_date": "2026-03-01",
+        }
+        self.block_repository_mock.get_block.return_value = active_block
+        self.block_repository_mock.get_blocks_by_athlete.return_value = [active_block]
+        self.week_repository_mock.get_weeks_by_block.return_value = [
+            {"week_id": "w1", "week_number": 1}
+        ]
+        self.day_repository_mock.batch_get_days_by_week_ids.return_value = [
+            {"day_id": "d1", "week_id": "w1", "date": today}
+        ]
+        self.exercise_repository_mock.batch_get_exercises_by_day_ids.return_value = []
+
+        result = self.analytics_service.get_dashboard_summary("athlete-1", "only-block")
+
+        self.assertNotIn("error", result)
+        for lift in ["Squat", "Bench Press", "Deadlift"]:
+            self.assertIsNone(result["prs"][lift]["delta"])
+
+    def test_get_dashboard_summary_missing_params(self):
+        """Returns error dict when athlete_id or block_id is empty"""
+        result = self.analytics_service.get_dashboard_summary("", "block-1")
+        self.assertIn("error", result)
+
+        result = self.analytics_service.get_dashboard_summary("athlete-1", "")
+        self.assertIn("error", result)
+
+    def test_get_block_sbd_bests_repository_failure_returns_empty(self):
+        """If previous block repository calls fail, _get_block_sbd_bests returns {} gracefully"""
+        self.week_repository_mock.get_weeks_by_block.side_effect = Exception(
+            "DynamoDB unavailable"
+        )
+        result = self.analytics_service._get_block_sbd_bests("some-block-id")
+        self.assertEqual(result, {})
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/flow-frontend/src/pages/Dashboard.tsx
+++ b/flow-frontend/src/pages/Dashboard.tsx
@@ -4,8 +4,8 @@ import Layout from '../components/Layout';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { getBlocks, getCoachRelationships, getUser } from '../services/api';
-import type { Block } from '../services/api';
+import { getBlocks, getCoachRelationships, getUser, getDashboardSummary } from '../services/api';
+import type { Block, DashboardSummary } from '../services/api';
 import { formatDate } from '../utils/dateUtils';
 import TodaysWorkoutCard from '../components/TodaysWorkoutCard';
 
@@ -19,6 +19,7 @@ const Dashboard = ({ user, signOut }: DashboardProps) => {
   const [isLoading, setIsLoading] = useState(true);
   const [athletes, setAthletes] = useState<any[]>([]);
   const [isLoadingAthletes, setIsLoadingAthletes] = useState(false);
+  const [dashboardSummary, setDashboardSummary] = useState<DashboardSummary | null>(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -27,6 +28,14 @@ const Dashboard = ({ user, signOut }: DashboardProps) => {
         const blocksData = await getBlocks(user.user_id);
         const active = (blocksData || []).find(block => block.status === 'active');
         setActiveBlock(active || null);
+        if (active) {
+          try {
+            const summary = await getDashboardSummary(user.user_id, active.block_id);
+            setDashboardSummary(summary);
+          } catch {
+            // summary cards are best-effort; fail silently
+          }
+        }
       } catch (error) {
         console.error('Error fetching blocks:', error);
         setActiveBlock(null);
@@ -115,6 +124,71 @@ const Dashboard = ({ user, signOut }: DashboardProps) => {
           <>
             {/* Today's Workout - PRIMARY FOCUS */}
             <TodaysWorkoutCard activeBlock={activeBlock} userId={user.user_id} />
+
+            {/* SBD PR Cards */}
+            {dashboardSummary && (
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                {(['Squat', 'Bench Press', 'Deadlift'] as const).map((lift) => {
+                  const pr = dashboardSummary.prs[lift];
+                  if (!pr) return null;
+                  return (
+                    <div key={lift} className="bg-white rounded-lg border border-gray-200 p-3 text-center">
+                      <p className="text-xs font-medium text-ocean-slate truncate">{lift}</p>
+                      <p className="text-xl font-bold text-ocean-navy mt-1">
+                        {pr.current_block_best > 0
+                          ? `${pr.current_block_best}${user.weight_unit_preference === 'lb' ? 'lb' : 'kg'}`
+                          : '—'}
+                      </p>
+                      {pr.delta !== null && (
+                        <p className={`text-xs mt-0.5 ${pr.delta >= 0 ? 'text-state-active' : 'text-red-600'}`}>
+                          {pr.delta >= 0 ? '↑' : '↓'}{Math.abs(pr.delta)}{user.weight_unit_preference === 'lb' ? 'lb' : 'kg'}
+                        </p>
+                      )}
+                      {pr.delta === null && pr.current_block_best > 0 && (
+                        <p className="text-xs mt-0.5 text-ocean-slate-light">first block</p>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {/* Weekly Volume Card */}
+            {dashboardSummary?.weekly_volume?.current_week_number && (
+              <div className="bg-white rounded-lg border border-gray-200 p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-xs font-medium text-ocean-slate">
+                      Week {dashboardSummary.weekly_volume.current_week_number} Volume
+                    </p>
+                    <p className="text-2xl font-bold text-ocean-navy mt-0.5">
+                      {dashboardSummary.weekly_volume.current_week_volume > 0
+                        ? `${dashboardSummary.weekly_volume.current_week_volume.toLocaleString()}${user.weight_unit_preference === 'lb' ? 'lb' : 'kg'}`
+                        : '—'}
+                    </p>
+                    {dashboardSummary.weekly_volume.previous_week_volume !== undefined && (
+                      (() => {
+                        const delta =
+                          dashboardSummary.weekly_volume.current_week_volume -
+                          dashboardSummary.weekly_volume.previous_week_volume!;
+                        return (
+                          <p className={`text-xs mt-0.5 ${delta >= 0 ? 'text-state-active' : 'text-red-600'}`}>
+                            {delta >= 0 ? '↑' : '↓'}{Math.abs(delta).toLocaleString()}{user.weight_unit_preference === 'lb' ? 'lb' : 'kg'}
+                            {' '}vs Week {dashboardSummary.weekly_volume.previous_week_number}
+                          </p>
+                        );
+                      })()
+                    )}
+                  </div>
+                  <Link
+                    to="/analytics"
+                    className="text-sm font-medium text-ocean-teal hover:text-ocean-navy"
+                  >
+                    Analytics →
+                  </Link>
+                </div>
+              </div>
+            )}
 
             {/* Current Program - demoted to context line */}
             {activeBlock && (

--- a/flow-frontend/src/services/api.ts
+++ b/flow-frontend/src/services/api.ts
@@ -1741,6 +1741,58 @@ export const getBlockAnalysis = async (
   }
 };
 
+export interface DashboardSummary {
+  prs: {
+    [lift: string]: {
+      current_block_best: number;
+      previous_block_best: number;
+      delta: number | null;
+    };
+  };
+  weekly_volume: {
+    current_week_number: number;
+    current_week_volume: number;
+    previous_week_number?: number;
+    previous_week_volume?: number;
+  };
+}
+
+export const getDashboardSummary = async (
+  athleteId: string,
+  blockId: string
+): Promise<DashboardSummary | null> => {
+  try {
+    const headers = await getAuthHeaders();
+
+    const path = `/analytics/dashboard-summary/${athleteId}?block_id=${blockId}`;
+
+    console.log('Fetching dashboard summary for athlete:', athleteId, 'block:', blockId);
+    const apiResponse = await get({
+      apiName: 'flow-api',
+      path,
+      options: { headers },
+    });
+
+    const actualResponse = await apiResponse.response;
+
+    if (actualResponse && actualResponse.body) {
+      try {
+        const responseData = await actualResponse.body.json() as any;
+        console.log('Dashboard summary data:', responseData);
+        return responseData as DashboardSummary;
+      } catch (e) {
+        console.error('Failed to parse dashboard summary data:', e);
+        return null;
+      }
+    }
+
+    return null;
+  } catch (error) {
+    console.error('Error fetching dashboard summary:', error);
+    return null;
+  }
+};
+
 export const getBlockComparison = async (
   athleteId: string,
   block1Id: string,


### PR DESCRIPTION
**Backend**
`analytics_service.py`:
- `get_dashboard_summary()` + helpers (`_extract_sbd_bests`, `_get_block_sbd_bests`, `_compute_weekly_volume`, `_find_previous_block`)

`analytics_api.py`:
- `GET /analytics/dashboard-summary/{athlete_id}` handler with auth + block ownership checks

`analytics_lambda.py`: 
- route registered in `ROUTE_MAP`

`app-stack.yaml`:
- `DashboardSummary` API Gateway event added (missing entry was causing CORS 403 on preflight)
- Exercise retrieval rewritten to use `get_exercises_with_workout_context(athlete_id, start_date=...)` instead of `batch_get_exercises_by_day_ids`. Exercises don't have `day_id` in DynamoDB; the correct traversal path is Block -> Week -> Day -> Workout -> Exercise

**Frontend**
- `api.ts`: `DashboardSummary` interface + `getDashboardSummary()` using Amplify `get()` pattern
- `Dashboard.tsx`: SBD PR grid (responsive, `grid-cols-1 sm:grid-cols-3`) + weekly volume card, both best-effort (errors swallowed silently), hidden when no active block